### PR TITLE
DEBUG mode error in tests

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -114,11 +114,6 @@
 					<type>test-jar</type>
 				</dependency>
 				<dependency>
-					<groupId>org.openmrs.web</groupId>
-					<artifactId>openmrs-web</artifactId>
-					<type>test-jar</type>
-				</dependency>
-				<dependency>
 					<groupId>org.openmrs.test</groupId>
 					<artifactId>openmrs-test</artifactId>
 					<type>pom</type>
@@ -135,11 +130,6 @@
 					<type>test-jar</type>
 				</dependency>
 				<dependency>
-					<groupId>org.openmrs.web</groupId>
-					<artifactId>openmrs-web</artifactId>
-					<type>test-jar</type>
-				</dependency>
-				<dependency>
 					<groupId>org.openmrs.test</groupId>
 					<artifactId>openmrs-test</artifactId>
 					<type>pom</type>
@@ -153,11 +143,6 @@
 				<dependency>
 					<groupId>org.openmrs.api</groupId>
 					<artifactId>openmrs-api</artifactId>
-					<type>test-jar</type>
-				</dependency>
-				<dependency>
-					<groupId>org.openmrs.web</groupId>
-					<artifactId>openmrs-web</artifactId>
 					<type>test-jar</type>
 				</dependency>
 				<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -168,27 +168,6 @@
 						</lifecycleMappingMetadata>
 					</configuration>
 				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-dependency-plugin</artifactId>
-					<executions>
-						<execution>
-							<id>Expand moduleApplicationContext and messages</id>
-							<goals>
-								<goal>unpack-dependencies</goal>
-							</goals>
-							<phase>generate-resources</phase>
-							<configuration>
-								<includeGroupIds>${project.parent.groupId}</includeGroupIds>
-								<includeArtifactIds>${project.parent.artifactId}-api</includeArtifactIds>
-								<excludeTransitive>true</excludeTransitive>
-								<includes>**/moduleApplicationContext.xml,
-									**\messages*.properties</includes>
-								<outputDirectory>${project.build.directory}/classes</outputDirectory>
-							</configuration>
-						</execution>
-					</executions>
-				</plugin>
 			</plugins>
 		</pluginManagement>
 	</build>


### PR DESCRIPTION
This fixes the fact that relationships are only saved if in DEBUG logging mode.
See https://tickets.openmrs.org/browse/HTML-362

The previous pull request for the log4j.xml file should be able to be included again.
