### PR TITLE
NPE when saving or creating a form when there is a PersonAttributeType with null format

### DIFF
--- a/api/src/main/java/org/openmrs/module/htmlformentry/HtmlFormEntryUtil.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/HtmlFormEntryUtil.java
@@ -357,7 +357,7 @@ public class HtmlFormEntryUtil {
 		}
 		
 		for (PersonAttributeType type : Context.getPersonService().getAllPersonAttributeTypes()) {
-			if (type.getFormat().equals("java.lang.String")) {
+			if (type.getFormat() != null && type.getFormat().equals("java.lang.String")) {
 				demo.addAttribute(new PersonAttribute(type, "Test " + type.getName() + " Attribute"));
 			}
 		}


### PR DESCRIPTION
PersonAttributesTypes aren't required to have the format field filled
in, this was causing a NPE to occur when saving or creating any form
when a PersonAttributeType exists in the system with a null format.
