### PR TITLE
Fix for HTML-413 (Identifier tag overwrites preferred identifier regardless of type)

### DIFF
--- a/api/src/main/java/org/openmrs/module/htmlformentry/element/PatientDetailSubmissionElement.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/element/PatientDetailSubmissionElement.java
@@ -331,28 +331,41 @@ public class PatientDetailSubmissionElement implements HtmlGeneratorElement, For
 		}
  
 		if (identifierTypeValueWidget != null && identifierTypeWidget != null) {
-			PatientIdentifier patientIdentifier = patient.getPatientIdentifier();
+			String identifier = (String) identifierTypeValueWidget.getValue(context, request);
+			PatientIdentifierType identifierType = getIdentifierType((String) identifierTypeWidget.getValue(context, request));
+
+			// Look for an existing identifier of this type
+			PatientIdentifier patientIdentifier = patient.getPatientIdentifier(identifierType);
+
+			// No existing identifier of this type, so create new
 			if (patientIdentifier == null) {
 				patientIdentifier = new PatientIdentifier();
+				patientIdentifier.setIdentifierType(identifierType);
+
 				// HACK: we need to set the date created  and uuid here as a hack around a hibernate flushing issue (see saving the Patient in FormEntrySession applyActions())
 				patientIdentifier.setDateChanged(new Date());
 				patientIdentifier.setUuid(UUID.randomUUID().toString());
+
+				// For 1.9+ onwards patients require a preferred identifier
+				if (patient.getPatientId() == null) {
+					patientIdentifier.setPreferred(true);
+				}
+
 				patient.addIdentifier(patientIdentifier);
 			}
-			
-			String identifier = (String) identifierTypeValueWidget.getValue(context, request);
-			
-			PatientIdentifierType identifierType = getIdentifierType((String) identifierTypeWidget.getValue(context, request));
 
 			if (!identifier.equals(patientIdentifier.getIdentifier()) || !identifierType.equals(patientIdentifier.getIdentifierType())) {
 				validateIdentifier(identifierType.getId(), identifier);
 			}
-			
-			patientIdentifier.setIdentifierType(identifierType);
+
 			patientIdentifier.setIdentifier(identifier);
-			patientIdentifier.setPreferred(true);
 		}
 
+		//
+		// TODO current behavior always updates location of the preferred identifier rather than
+		// a specific identifier type being edited by the identifier widget. But identifier location
+		// widget isn't aware of the identifier type widget
+		//
 		if (identifierLocationWidget != null) {
 			PatientIdentifier patientIdentifier = patient.getPatientIdentifier();
 			if (patientIdentifier == null) {
@@ -361,7 +374,7 @@ public class PatientDetailSubmissionElement implements HtmlGeneratorElement, For
 			}
 
 			Object locationString = identifierLocationWidget.getValue(context, request);
-            Location location = (Location) HtmlFormEntryUtil.convertToType(locationString.toString().trim(), Location.class);
+			Location location = (Location) HtmlFormEntryUtil.convertToType(locationString.toString().trim(), Location.class);
 			patientIdentifier.setLocation(location);
 			patientIdentifier.setPreferred(true);
 

--- a/api/src/test/java/org/openmrs/module/htmlformentry/PatientTagTest.java
+++ b/api/src/test/java/org/openmrs/module/htmlformentry/PatientTagTest.java
@@ -64,11 +64,10 @@ public class PatientTagTest extends BaseModuleContextSensitiveTest {
 				request.setParameter(widgets.get("PersonName.familyName"), "Family");
 				request.setParameter(widgets.get("Gender:"), "F");
 				request.setParameter(widgets.get("Birthdate:"), dateAsString(date));
-				request.setParameter(widgets.get("Identifier:"), "9234923dfasd2");
+				request.setParameter(widgets.get("Identifier:"), "987654-1");
 				request.setParameter(widgets.get("Identifier Location:"), "2");
 				// hack because identifier type is a hidden input with no label
-				request.setParameter("w17", "2");
-				
+				request.setParameter("w17", "1");
 			}
 			
 			@Override
@@ -107,10 +106,10 @@ public class PatientTagTest extends BaseModuleContextSensitiveTest {
 				request.setParameter(widgets.get("PersonName.familyName"), "Family");
 				request.setParameter(widgets.get("Gender:"), "F");
 				request.setParameter(widgets.get("Birthdate:"), dateAsString(date));
-				request.setParameter(widgets.get("Identifier:"), "9234923dfasd2");
+				request.setParameter(widgets.get("Identifier:"), "987654-1");
 				request.setParameter(widgets.get("Identifier Location:"), "2");
 				// hack because identifier type is a hidden input with no label
-				request.setParameter("w17", "2");
+				request.setParameter("w17", "1");
 				
 				request.setParameter(widgets.get("Date:"), dateAsString(date));
 				request.setParameter(widgets.get("Encounter Location:"), "2");
@@ -128,7 +127,7 @@ public class PatientTagTest extends BaseModuleContextSensitiveTest {
 				Assert.assertEquals("F", results.getPatient().getGender());
 				Assert.assertEquals(datePartOnly, results.getPatient().getBirthdate());
 				Assert.assertEquals(false, results.getPatient().getBirthdateEstimated());
-				Assert.assertEquals("9234923dfasd2", results.getPatient().getPatientIdentifier().getIdentifier());
+				Assert.assertEquals("987654-1", results.getPatient().getPatientIdentifier().getIdentifier());
 				
 				results.assertEncounterCreated();
 				Assert.assertEquals(datePartOnly, results.getEncounterCreated().getEncounterDatetime());
@@ -559,10 +558,10 @@ public class PatientTagTest extends BaseModuleContextSensitiveTest {
 				request.setParameter(widgets.get("PersonName.familyName"), "Family");
 				request.setParameter(widgets.get("Gender:"), "F");
 				request.setParameter(widgets.get("Birthdate:"), dateAsString(date));
-				request.setParameter(widgets.get("Identifier:"), "9234923dfasd2");
+				request.setParameter(widgets.get("Identifier:"), "987654-1");
 				request.setParameter(widgets.get("Identifier Location:"), "2");
 				// hack because identifier type is a hidden input with no label
-				request.setParameter("w17", "2");
+				request.setParameter("w17", "1");
 				
 				request.setParameter(widgets.get("Date:"), dateAsString(date));
 				request.setParameter(widgets.get("Encounter Location:"), "2");
@@ -585,7 +584,7 @@ public class PatientTagTest extends BaseModuleContextSensitiveTest {
 				Assert.assertEquals("F", results.getPatient().getGender());
 				Assert.assertEquals(datePartOnly, results.getPatient().getBirthdate());
 				Assert.assertEquals(false, results.getPatient().getBirthdateEstimated());
-				Assert.assertEquals("9234923dfasd2", results.getPatient().getPatientIdentifier().getIdentifier());
+				Assert.assertEquals("987654-1", results.getPatient().getPatientIdentifier().getIdentifier());
 				
 				results.assertEncounterCreated();
 				Assert.assertEquals(datePartOnly, results.getEncounterCreated().getEncounterDatetime());
@@ -628,10 +627,10 @@ public class PatientTagTest extends BaseModuleContextSensitiveTest {
                 request.setParameter(widgets.get("PersonName.familyName"), "Family");
                 request.setParameter(widgets.get("Gender:"), "F");
                 request.setParameter(widgets.get("Birthdate:"), dateAsString(date));
-                request.setParameter(widgets.get("Identifier:"), "9234923dfasd2");
+                request.setParameter(widgets.get("Identifier:"), "987654-1");
                 request.setParameter(widgets.get("Identifier Location:"), "2");
                 // hack because identifier type is a hidden input with no label
-                request.setParameter("w17", "2");
+                request.setParameter("w17", "1");
 
                 request.setParameter(widgets.get("Date:"), dateAsString(date));
             }
@@ -648,7 +647,7 @@ public class PatientTagTest extends BaseModuleContextSensitiveTest {
                 Assert.assertEquals("F", results.getPatient().getGender());
                 Assert.assertEquals(datePartOnly, results.getPatient().getBirthdate());
                 Assert.assertEquals(false, results.getPatient().getBirthdateEstimated());
-                Assert.assertEquals("9234923dfasd2", results.getPatient().getPatientIdentifier().getIdentifier());
+                Assert.assertEquals("987654-1", results.getPatient().getPatientIdentifier().getIdentifier());
 
                 List<PatientProgram> patientPrograms = Context.getProgramWorkflowService().getPatientPrograms(
                 		results.getPatient(), null, null, null, null, null, false);
@@ -692,10 +691,10 @@ public class PatientTagTest extends BaseModuleContextSensitiveTest {
 				request.setParameter(widgets.get("PersonName.familyName"), "Family");
 				request.setParameter(widgets.get("Gender:"), "F");
 				request.setParameter(widgets.get("Birthdate:"), dateAsString(date));
-				request.setParameter(widgets.get("Identifier:"), "9234923dfasd2");
+				request.setParameter(widgets.get("Identifier:"), "987654-1");
 				request.setParameter(widgets.get("Identifier Location:"), "2");
 				// hack because identifier type is a hidden input with no label
-				request.setParameter("w17", "2");
+				request.setParameter("w17", "1");
 				
 				request.setParameter(widgets.get("Date:"), dateAsString(date));
 				request.setParameter(widgets.get("Encounter Location:"), "2");
@@ -712,10 +711,10 @@ public class PatientTagTest extends BaseModuleContextSensitiveTest {
 				request.setParameter(widgets.get("PersonName.familyName"), "Family");
 				request.setParameter(widgets.get("Gender:"), "F");
 				request.setParameter(widgets.get("Birthdate:"), dateAsString(date));
-				request.setParameter(widgets.get("Identifier:"), "9234923dfasd2");
+				request.setParameter(widgets.get("Identifier:"), "987654-1");
 				request.setParameter(widgets.get("Identifier Location:"), "2");
 				// hack because identifier type is a hidden input with no label
-				request.setParameter("w17", "2");
+				request.setParameter("w17", "1");
 			}
 			
 			@Override
@@ -747,7 +746,7 @@ public class PatientTagTest extends BaseModuleContextSensitiveTest {
 				Assert.assertEquals("F", results.getPatient().getGender());
 				Assert.assertEquals(datePartOnly, results.getPatient().getBirthdate());
 				Assert.assertEquals(false, results.getPatient().getBirthdateEstimated());
-				Assert.assertEquals("9234923dfasd2", results.getPatient().getPatientIdentifier().getIdentifier());
+				Assert.assertEquals("987654-1", results.getPatient().getPatientIdentifier().getIdentifier());
 			}
 		}.run();
 	}
@@ -786,10 +785,10 @@ public class PatientTagTest extends BaseModuleContextSensitiveTest {
 				request.setParameter(widgets.get("PersonName.familyName"), "Family");
 				request.setParameter(widgets.get("Gender:"), "F");
 				request.setParameter(widgets.get("Birthdate:"), dateAsString(date));
-				request.setParameter(widgets.get("Identifier:"), "9234923dfasd2");
+				request.setParameter(widgets.get("Identifier:"), "987654-1");
 				request.setParameter(widgets.get("Identifier Location:"), "2");
 				// hack because identifier type is a hidden input with no label
-				request.setParameter("w17", "2");
+				request.setParameter("w17", "1");
 				
 				request.setParameter(widgets.get("Date:"), dateAsString(date));
 				request.setParameter(widgets.get("Encounter Location:"), "2");
@@ -812,7 +811,7 @@ public class PatientTagTest extends BaseModuleContextSensitiveTest {
 				Assert.assertEquals("F", results.getPatient().getGender());
 				Assert.assertEquals(datePartOnly, results.getPatient().getBirthdate());
 				Assert.assertEquals(false, results.getPatient().getBirthdateEstimated());
-				Assert.assertEquals("9234923dfasd2", results.getPatient().getPatientIdentifier().getIdentifier());
+				Assert.assertEquals("987654-1", results.getPatient().getPatientIdentifier().getIdentifier());
 				
 				results.assertEncounterEdited();
 				Assert.assertEquals(datePartOnly, results.getEncounterCreated().getEncounterDatetime());
@@ -871,10 +870,10 @@ public class PatientTagTest extends BaseModuleContextSensitiveTest {
 				request.setParameter(widgets.get("PersonName.familyName"), "Family");
 				request.setParameter(widgets.get("Gender:"), "F");
 				request.setParameter(widgets.get("Birthdate:"), dateAsString(date));
-				request.setParameter(widgets.get("Identifier:"), "9234923dfasd2");
+				request.setParameter(widgets.get("Identifier:"), "987654-1");
 				request.setParameter(widgets.get("Identifier Location:"), "2");
 				// hack because identifier type is a hidden input with no label
-				request.setParameter("w17", "2");
+				request.setParameter("w17", "1");
 				request.addParameter(widgets.get("Location.address1"), "410 w 10th St.");
 				request.addParameter(widgets.get("Location.cityVillage"), "Indianapolis");
 				request.addParameter(widgets.get("Location.stateProvince"), "Indiana");
@@ -943,10 +942,10 @@ public class PatientTagTest extends BaseModuleContextSensitiveTest {
 				request.setParameter(widgets.get("PersonName.familyName"), "Family");
 				request.setParameter(widgets.get("Gender:"), "F");
 				request.setParameter(widgets.get("Birthdate:"), dateAsString(date));
-				request.setParameter(widgets.get("Identifier:"), "9234923dfasd2");
+				request.setParameter(widgets.get("Identifier:"), "987654-1");
 				request.setParameter(widgets.get("Identifier Location:"), "2");
 				// hack because identifier type is a hidden input with no label
-				request.setParameter("w17", "2");
+				request.setParameter("w17", "1");
 				request.addParameter(widgets.get("Location.address1"), "410 w 10th St.");
 				request.addParameter(widgets.get("Location.cityVillage"), "Indianapolis");
 				request.addParameter(widgets.get("Location.stateProvince"), "Indiana");


### PR DESCRIPTION
Changed handleSubmission of PatientDetailSubmissionElement so that it only overwrites an existing identifier with the type specified by the identifier type widget

This commit doesn't address the related problem of the identifier location widget which still overwrites the default identifier regardless of its type
