### PR TITLE
HTML-449: Updated velocity methods to accept string

### DIFF
--- a/api-tests/src/test/java/org/openmrs/module/htmlformentry/VelocityFunctionsTest.java
+++ b/api-tests/src/test/java/org/openmrs/module/htmlformentry/VelocityFunctionsTest.java
@@ -8,6 +8,7 @@ import org.joda.time.Months;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openmrs.Concept;
+import org.openmrs.Encounter;
 import org.openmrs.EncounterType;
 import org.openmrs.Form;
 import org.openmrs.Obs;
@@ -18,6 +19,7 @@ import org.openmrs.test.BaseModuleContextSensitiveTest;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.List;
 
 public class VelocityFunctionsTest extends BaseModuleContextSensitiveTest {
 
@@ -98,8 +100,8 @@ public class VelocityFunctionsTest extends BaseModuleContextSensitiveTest {
 	@Test
 	public void latestEncounter_shouldReturnTheMostRecentEncounterByType() throws Exception {
 		VelocityFunctions functions = setupFunctionsForPatient(7); 
-		EncounterType type = Context.getEncounterService().getEncounterType(2);
-        Assert.assertEquals(new Integer(3), functions.latestEncounter(type).getEncounterId());
+		Encounter latestEncounter = functions.latestEncounter("2");
+        Assert.assertEquals(new Integer(3), latestEncounter.getEncounterId());
 	}
 	
 	/**
@@ -108,9 +110,18 @@ public class VelocityFunctionsTest extends BaseModuleContextSensitiveTest {
 	 */
 	@Test
 	public void latestEncounter_shouldReturnNullIfNoMatchingEncounter() throws Exception {
-		VelocityFunctions functions = setupFunctionsForPatient(7); 
-		EncounterType type = Context.getEncounterService().getEncounterType(6);
-        Assert.assertNull(functions.latestEncounter(type));
+		VelocityFunctions functions = setupFunctionsForPatient(7);
+        Assert.assertNull(functions.latestEncounter("6"));
+	}
+	
+	/**
+	 * @see VelocityFunctions@allEncounters(EncounterType)
+	 * @verifies return all the encounters of the specified type
+	 */
+	public void allEncounters_shouldReturnAllTheEncountersOfTheSpecifiedType() throws Exception {
+		VelocityFunctions functions = setupFunctionsForPatient(7);
+		List<Encounter> allEncounters = functions.allEncounters("2");
+		Assert.assertEquals(1, allEncounters.size());
 	}
 
     /**

--- a/api/src/main/java/org/openmrs/module/htmlformentry/VelocityFunctions.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/VelocityFunctions.java
@@ -1,5 +1,6 @@
 package org.openmrs.module.htmlformentry;
 
+import org.apache.commons.lang.StringUtils;
 import org.joda.time.DateTime;
 import org.joda.time.Days;
 import org.joda.time.LocalDate;
@@ -130,7 +131,12 @@ public class VelocityFunctions {
 	 * @should return all the encounters of the specified type
 	 * @should return all encounters if no type specified
 	 */
-	public List<Encounter> allEncounters(EncounterType type) {
+    public List<Encounter> allEncounters(String encounterTypeId){
+		EncounterType encounterType = HtmlFormEntryUtil.getEncounterType(encounterTypeId);
+		return getAllEncounters(encounterType);
+    }
+    
+	private List<Encounter> getAllEncounters(EncounterType type) {
 		if (session.getPatient() == null) {
 			return new ArrayList<Encounter>();
 		}
@@ -156,8 +162,17 @@ public class VelocityFunctions {
 	 * @should return the most recent encounter of the specified type
 	 * @should return the most recent encounter of any type if no type specified
 	 */
-	public Encounter latestEncounter(EncounterType type) {
-		List<Encounter> encounters = allEncounters(type);
+	public Encounter latestEncounter(String encounterTypeId){
+		EncounterType encounterType = null;
+		if (StringUtils.isNotEmpty(encounterTypeId)) {
+			encounterType = HtmlFormEntryUtil.getEncounterType(encounterTypeId);			
+		}
+		
+		return getLatestEncounter(encounterType);
+	}
+	
+	private Encounter getLatestEncounter(EncounterType type) {
+		List<Encounter> encounters = getAllEncounters(type);
 		if (encounters == null || encounters.isEmpty()) {
 			return null;
 		}


### PR DESCRIPTION
https://issues.openmrs.org/browse/HTML-449

Changed definition of allEncounters() and latestEncounter to accept strings.
