### PR TITLE
Open complex obs in browser new tab or new window

### DIFF
--- a/api/src/main/java/org/openmrs/module/htmlformentry/widget/WidgetFactory.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/widget/WidgetFactory.java
@@ -147,8 +147,8 @@ public class WidgetFactory {
 				if (ImageHandler.class.isAssignableFrom(Class.forName(AbstractHandler.class.getPackage().getName() + "."
 				        + complex.getHandler()))) {
 					String imgTag = "<img src='" + hyperlink + "' class=\"complexImage\" />";
-					return "<a href=\"" + hyperlink + "\">" + imgTag + "</a><br/><a href=\"" + getDownloadHyperlink(obs)
-					        + "\">" + Context.getMessageSourceService().getMessage("htmlformentry.form.complex.download")
+					return "<a href=\"" + hyperlink + "\" target=\"_blank\">" + imgTag + "</a><br/><a href=\"" + getDownloadHyperlink(obs)
+					        + "\" target=\"_blank\">" + Context.getMessageSourceService().getMessage("htmlformentry.form.complex.download")
 					        + "</a>";
 				}
 			}
@@ -157,9 +157,9 @@ public class WidgetFactory {
 		
 		File file = AbstractHandler.getComplexDataFile(obs);
 		String fileName = file.getName();
-		String value = "<p class=\"value\">" + fileName + "<br/><a href=\"" + hyperlink + "\">"
+		String value = "<p class=\"value\">" + fileName + "<br/><a href=\"" + hyperlink + "\" target=\"_blank\">"
 		        + Context.getMessageSourceService().getMessage("htmlformentry.form.complex.view") + "</a> | <a href=\""
-		        + getDownloadHyperlink(obs) + "\">"
+		        + getDownloadHyperlink(obs) + "\" target=\"_blank\">"
 		        + Context.getMessageSourceService().getMessage("htmlformentry.form.complex.download") + "</a></p>";
 		return "<span>" + value + "</span>";
 	}


### PR DESCRIPTION
When opening a complex observation for view or download, by default the form is closed and the complex obs is displayed in the current window. If a user click on "view complex obs" while entering data, a message is thrown warning about data loses (data is not really lost, but it something scaring for users). So maybe the best approach is to open complex obs in new tabs or windows.
I did not open a ticket for this because I thought it was no necessary. Anyway, if you think this commit is not useful, just reject it.
Regards
