### PR TITLE
HTML-381: Added validation while processing obs and obsgroup

### DIFF
--- a/api-tests/src/test/java/org/openmrs/module/htmlformentry/HtmlFormValidatorTest.java
+++ b/api-tests/src/test/java/org/openmrs/module/htmlformentry/HtmlFormValidatorTest.java
@@ -13,7 +13,7 @@
  */
 package org.openmrs.module.htmlformentry;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openmrs.EncounterType;
 import org.openmrs.Form;
@@ -64,5 +64,49 @@ public class HtmlFormValidatorTest extends BaseModuleContextSensitiveTest {
 		Errors errors = new BindException(htmlForm, "htmlForm");
 		new HtmlFormValidator().validate(htmlForm, errors);
 		Assert.assertTrue(errors.hasFieldErrors("xmlData"));
+	}
+
+	@Test
+	public void validate_shouldAllowXmlWithValidObsGroupAndSetMembers() throws Exception {
+		String xml = "<htmlform>"
+				+ "<obsgroup groupingConceptId=\"23\">"
+				+ "<obs conceptId=\"18\" />"
+				+ "</obsgroup>"
+				+ "Date: <encounterDate/>Location: <encounterLocation/>"
+				+ "Provider: <encounterProvider role=\"Provider\"/>"
+				+ "Encounter Type: <encounterType /> <submit/>"
+				+ "</htmlform>";
+		HtmlForm htmlForm = new HtmlForm();
+		Form form = Context.getFormService().getForm(1);
+		htmlForm.setXmlData(xml);
+		htmlForm.setForm(form);
+		Errors errors = new BindException(htmlForm, "htmlForm");
+		HtmlFormValidator validator = new HtmlFormValidator();
+		validator.validate(htmlForm, errors);
+		Assert.assertEquals(0, errors.getErrorCount());
+		Assert.assertEquals(0, validator.getHtmlFormWarnings().size());
+	}
+	
+	@Test
+	public void validate_shouldWarnWhenXmlObsGroupIsNotASet() throws Exception {
+		String xml = "<htmlform>"
+				+ "<obsgroup groupingConceptId=\"10\">\n"
+				+ "<obs conceptId=\"3\" />\n"
+				+ "<obs conceptId=\"4\" />\n"
+				+ "</obsgroup>\n"
+				+ "Date: <encounterDate/>Location: <encounterLocation/>"
+				+ "Provider: <encounterProvider role=\"Provider\"/>"
+				+ "Encounter Type: <encounterType />"
+				+ "<submit/>"
+				+ "</htmlform>";
+		HtmlForm htmlForm = new HtmlForm();
+		Form form = Context.getFormService().getForm(1);
+		htmlForm.setXmlData(xml);
+		htmlForm.setForm(form);
+		Errors errors = new BindException(htmlForm, "htmlForm");
+		HtmlFormValidator validator = new HtmlFormValidator();
+		validator.validate(htmlForm, errors);
+		Assert.assertEquals(0, errors.getErrorCount());
+		Assert.assertEquals(3, validator.getHtmlFormWarnings().size());
 	}
 }

--- a/api-tests/src/test/java/org/openmrs/module/htmlformentry/handler/ObsGroupTagHandlerTest.java
+++ b/api-tests/src/test/java/org/openmrs/module/htmlformentry/handler/ObsGroupTagHandlerTest.java
@@ -1,0 +1,55 @@
+package org.openmrs.module.htmlformentry.handler;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openmrs.module.htmlformentry.HtmlFormEntryUtil;
+import org.openmrs.test.BaseModuleContextSensitiveTest;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+
+public class ObsGroupTagHandlerTest extends BaseModuleContextSensitiveTest {
+	
+	@Test
+	public void validate_shouldWarnWhenObsgroupConceptIsNotASet() throws Exception {
+		String xml = "<htmlform>\n"
+				+ "<obsgroup groupingConceptId=\"10\">\n"
+				+ "<obs conceptId=\"3\" />\n"
+				+ "<obs conceptId=\"4\" />\n"
+				+ "</obsgroup>\n"
+				+ "</htmlform>";
+		
+		Document document = HtmlFormEntryUtil.stringToDocument(xml);
+		Node obsGroupNode = HtmlFormEntryUtil.findDescendant(document, "obsgroup");
+		TagAnalysis analysis = new ObsGroupTagHandler().validate(obsGroupNode);
+		Assert.assertEquals(1, analysis.getWarnings().size());
+	}
+	
+	@Test
+	public void validate_shouldRejectXmlWhenObsgroupGroupingConceptIdIsMissing() throws Exception {
+		String xml = "<htmlform><obsgroup>TEST</obsgroup></htmlform>";
+		TagAnalysis analysis = validateObsGroupTag(xml);
+		Assert.assertEquals(1, analysis.getErrors().size());
+	}
+	
+	@Test
+	public void validate_shouldRejectXmlWhenObsgroupConceptCannotBeFound() throws Exception {
+		String xml = "<htmlform><obsgroup groupingConceptId=\"none\">TEST</obsgroup></htmlform>";
+		TagAnalysis analysis = validateObsGroupTag(xml);
+		Assert.assertEquals(1, analysis.getErrors().size());
+	}
+	
+	@Test
+	public void validate_shouldPassWhenObsGroupConceptIsASet() throws Exception {
+		String xml = "<htmlfom><obsgroup groupingConceptId=\"23\"><obs conceptId=\"xx\" /></obsgroup></htmlfom>";
+		TagAnalysis analysis = validateObsGroupTag(xml);
+		Assert.assertEquals(0, analysis.getErrors().size());
+	}
+	
+	private TagAnalysis validateObsGroupTag(String xml) throws Exception {
+		Document document = HtmlFormEntryUtil.stringToDocument(xml);
+		Node obsGroupNode = HtmlFormEntryUtil.findDescendant(document, "obsgroup");
+		TagAnalysis analysis = new ObsGroupTagHandler().validate(obsGroupNode);
+		return analysis;
+	}
+	
+}

--- a/api-tests/src/test/java/org/openmrs/module/htmlformentry/handler/ObsTagHandlerTest.java
+++ b/api-tests/src/test/java/org/openmrs/module/htmlformentry/handler/ObsTagHandlerTest.java
@@ -1,0 +1,90 @@
+package org.openmrs.module.htmlformentry.handler;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openmrs.module.htmlformentry.HtmlFormEntryUtil;
+import org.openmrs.test.BaseModuleContextSensitiveTest;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+
+public class ObsTagHandlerTest extends BaseModuleContextSensitiveTest {
+	
+	@Test
+	public void validate_shouldWarnWhenObsIsNotAMemberOfParentObsgroup() throws Exception {
+		String xml = "<htmlform>\n"
+				+ "<obsgroup groupingConceptId=\"23\">\n"
+				+ "<obs conceptId=\"4\" />\n"
+				+ "</obsgroup>\n </htmlform>";
+		Document document = HtmlFormEntryUtil.stringToDocument(xml);
+		Node parentObsGroupNode = HtmlFormEntryUtil.findDescendant(document, "obsgroup");
+		Assert.assertEquals("23", HtmlFormEntryUtil.getNodeAttribute(parentObsGroupNode, "groupingConceptId", null));
+		Node obsNode = HtmlFormEntryUtil.findChild(parentObsGroupNode, "obs");
+		TagAnalysis analysis = new ObsTagHandler().validate(obsNode);
+		Assert.assertEquals(1, analysis.getWarnings().size());	
+	}
+	
+	@Test
+	public void validate_shouldPassWhenObsIsAMemberOfParentObsgroup() throws Exception {
+		String xml = "<htmlform>\n"
+				+ "<obsgroup groupingConceptId=\"23\">\n"
+				+ "<obs conceptId=\"18\" />\n"
+				+ "	</obsgroup>\n </htmlform>";
+		
+		Document document = HtmlFormEntryUtil.stringToDocument(xml);
+		Node parentObsGroupNode = HtmlFormEntryUtil.findDescendant(document, "obsgroup");
+		Assert.assertEquals("23", HtmlFormEntryUtil.getNodeAttribute(parentObsGroupNode, "groupingConceptId", null));
+		
+		Node obsNode = HtmlFormEntryUtil.findChild(parentObsGroupNode, "obs");
+		TagAnalysis analysis = new ObsTagHandler().validate(obsNode);
+		Assert.assertEquals(0, analysis.getWarnings().size());
+	}
+	
+	@Test
+	public void validate_shouldRejectXmlWhenEitherObsConceptIdOrConceptIdsIsMissing() throws Exception {
+		String xml = "<htmlform><obs>TEST</obs></htmlform>";
+		TagAnalysis analysis = validateObsTag(xml);
+		Assert.assertEquals(1, analysis.getErrors().size());
+	}
+	
+	@Test
+	public void validate_shouldRejectXmlWhenBothObsConceptIdAndConceptIdsIsMissing() throws Exception {
+		String xml = "<htmlform><obs conceptId=\"xx\" conceptIds=\"xx,yy\">TEST</obs></htmlform>";
+		TagAnalysis analysis = validateObsTag(xml);
+		Assert.assertEquals(1, analysis.getErrors().size());
+	}
+	
+	@Test
+	public void validate_shouldRejectXmlWhenObsConceptCannotBeFound() throws Exception {
+		String xml = "<htmlform><obs conceptId=\"none\">TEST</obs></htmlform>";
+		TagAnalysis analysis = validateObsTag(xml);
+		Assert.assertEquals(1, analysis.getErrors().size());
+	}
+	
+	@Test
+	public void validate_shouldRejectXmlWhenOneOfObsConceptIdsCannotBeFound() throws Exception {
+		String xml = "<htmlform><obs conceptIds=\"18,none\">TEST</obs></htmlform>";
+		TagAnalysis analysis = validateObsTag(xml);
+		Assert.assertEquals(1, analysis.getErrors().size());
+	}
+	
+	@Test
+	public void validate_shouldPassWhenObsHasValidConceptId() throws Exception {
+		String xml = "<htmlform><obs conceptId=\"18\">TEST</obs></htmlform>";
+		TagAnalysis analysis = validateObsTag(xml);
+		Assert.assertEquals(0, analysis.getErrors().size());
+	}
+	
+	@Test
+	public void validate_shouldPassWhenObsHasValidConceptIds() throws Exception {
+		String xml = "<htmlform><obs conceptIds=\"18,19\">TEST</obs></htmlform>";
+		TagAnalysis analysis = validateObsTag(xml);
+		Assert.assertEquals(0, analysis.getErrors().size());
+	}
+	
+	private TagAnalysis validateObsTag(String xml) throws Exception {
+		Document document = HtmlFormEntryUtil.stringToDocument(xml);
+		Node obsNode = HtmlFormEntryUtil.findDescendant(document, "obs");
+		TagAnalysis analysis = new ObsTagHandler().validate(obsNode);
+		return analysis;
+	}
+}

--- a/api/src/main/java/org/openmrs/module/htmlformentry/handler/AbstractTagHandler.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/handler/AbstractTagHandler.java
@@ -17,7 +17,7 @@ import org.w3c.dom.Node;
  * Tag handlers that extend this class can override createAttributeDescriptors if they need
  * to specify attribute descriptors
  */
-public abstract class AbstractTagHandler implements TagHandler {
+public abstract class AbstractTagHandler implements TagHandler, TagValidator {
 
     /** Holds the attribute descriptors for this class **/
 	private List<AttributeDescriptor>  attributeDescriptors;
@@ -40,6 +40,11 @@ public abstract class AbstractTagHandler implements TagHandler {
 
     @Override
     abstract public void doEndTag(FormEntrySession session, PrintWriter out, Node parent, Node node) throws BadFormDesignException;
+    
+    @Override
+    public TagAnalysis validate(Node node) {
+        return new TagAnalysis();
+    }
 
     /**
      * Helper method for getting an attribute value, with a default.

--- a/api/src/main/java/org/openmrs/module/htmlformentry/handler/ObsGroupTagHandler.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/handler/ObsGroupTagHandler.java
@@ -2,6 +2,7 @@ package org.openmrs.module.htmlformentry.handler;
 
 import org.openmrs.Concept;
 import org.openmrs.Obs;
+import org.openmrs.api.context.Context;
 import org.openmrs.module.htmlformentry.FormEntryContext.Mode;
 import org.openmrs.module.htmlformentry.FormEntrySession;
 import org.openmrs.module.htmlformentry.HtmlFormEntryUtil;
@@ -110,6 +111,25 @@ public class ObsGroupTagHandler extends AbstractTagHandler {
 //                }
                  session.getContext().endObsGroup();
                  session.getSubmissionController().addAction(ObsGroupAction.end());
+    }
+	
+    @Override
+    public TagAnalysis validate(Node node) {
+        TagAnalysis analysis = new TagAnalysis();
+        String groupingConceptId = HtmlFormEntryUtil.getNodeAttribute(node, "groupingConceptId", null);
+        if (groupingConceptId == null) {
+            analysis.addError(Context.getMessageSourceService().getMessage("htmlformentry.error.groupingConceptIdMissing"));
+        }
+        Concept groupingConcept = HtmlFormEntryUtil.getConcept(groupingConceptId);
+        if (analysis.getErrors().size() == 0 && groupingConcept == null) {
+            analysis.addError(Context.getMessageSourceService().getMessage("htmlformentry.error.invalidConcept",
+                new Object[] { groupingConceptId }, null));
+        }
+        if (groupingConcept != null && !groupingConcept.isSet()) {
+            analysis.addWarning(Context.getMessageSourceService().getMessage("htmlformentry.warning.groupingConcept",
+                new Object[] { groupingConceptId }, null));
+        }
+        return analysis;
     }
     
 }

--- a/api/src/main/java/org/openmrs/module/htmlformentry/handler/TagAnalysis.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/handler/TagAnalysis.java
@@ -1,0 +1,30 @@
+package org.openmrs.module.htmlformentry.handler;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Holds a list of errors and warnings obtained from analysing a {@link Node} object
+ */
+public class TagAnalysis {
+    
+    private List<String> errors = new ArrayList<String>();
+    
+    private List<String> warnings = new ArrayList<String>();
+    
+    public void addError(String error) {
+        errors.add(error);
+    }
+    
+    public List<String> getErrors() {
+        return errors;
+    }
+    
+    public void addWarning(String warning) {
+        warnings.add(warning);
+    }
+    
+    public List<String> getWarnings() {
+        return warnings;
+    }
+}

--- a/api/src/main/java/org/openmrs/module/htmlformentry/handler/TagValidator.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/handler/TagValidator.java
@@ -1,0 +1,14 @@
+package org.openmrs.module.htmlformentry.handler;
+
+import org.w3c.dom.Node;
+
+public interface TagValidator {
+	
+	/**
+	 * Validates a document node and returns a {@link TagAnalysis} object
+	 * 
+	 * @param node to validate
+	 * @return {@link TagAnalysis}
+	 */
+	TagAnalysis validate(Node node);
+}

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -78,3 +78,8 @@ htmlformentry.drugOrder.careSetting                      = Care Setting
 htmlformentry.drugOrder.dosingType.simple                = Simple
 htmlformentry.drugOrder.dosingType.freetext              = Free Text
 htmlformentry.drugOrder.numRefills                       = Number of Refills
+htmlformentry.warning.invalidMember                      = Warning! obs concept ({0}) does not belong to the {1} obs group set
+htmlformentry.warning.groupingConcept                    = Warning! obs group ({0}) is not a set
+htmlformentry.error.groupingConceptIdMissing             = Error! obsgroup tag requires a groupingConceptId attribute
+htmlformentry.error.invalidConcept                       = Error! concept ({0}) does not exist
+htmlformentry.error.invalidConceptIdsAttribute           = Error! use either conceptId=\"({0})\" or conceptIds=\"({1})\"

--- a/omod/src/main/java/org/openmrs/module/htmlformentry/web/controller/HtmlFormController.java
+++ b/omod/src/main/java/org/openmrs/module/htmlformentry/web/controller/HtmlFormController.java
@@ -103,11 +103,15 @@ public class HtmlFormController {
 		if (htmlForm.getId() == null && StringUtils.isBlank(htmlForm.getXmlData())) {
 			htmlForm.setXmlData(service.getStartingFormXml(htmlForm));
 		}
-		new HtmlFormValidator().validate(htmlForm, result);
+		HtmlFormValidator validator = new HtmlFormValidator();
+		validator.validate(htmlForm, result);
+		if (validator.getHtmlFormWarnings().size() > 0) {
+			request.setAttribute("tagWarnings", validator.getHtmlFormWarnings(), WebRequest.SCOPE_SESSION);
+		}
 		if (result.hasErrors()) {
 			return null;
 		} else {
-	        htmlForm = service.saveHtmlForm(htmlForm);
+	        htmlForm = service.saveHtmlForm(htmlForm);	        
 	        request.setAttribute(WebConstants.OPENMRS_MSG_ATTR, "Saved " + htmlForm.getForm().getName() + " " + htmlForm.getForm().getVersion(), WebRequest.SCOPE_SESSION);
 			return "redirect:htmlForm.form?id=" + htmlForm.getId();
 		}

--- a/omod/src/main/webapp/htmlForm.jsp
+++ b/omod/src/main/webapp/htmlForm.jsp
@@ -1,4 +1,8 @@
 <%@ include file="/WEB-INF/template/include.jsp"%>
+<%
+	pageContext.setAttribute("tagWarnings", session.getAttribute("tagWarnings"));
+	session.removeAttribute("tagWarnings");
+%>
 
 <openmrs:require privilege="Manage Forms" otherwise="/login.htm" redirect="/module/htmlformentry/htmlForm.list" />
 
@@ -272,7 +276,12 @@
 					<c:if test="${status.errorMessage != ''}">
 						<span class="error">${status.errorMessage}</span>
 					</c:if>
-				</spring:bind>
+				</spring:bind>								
+				<c:if test="${tagWarnings != null}">
+					<c:forEach items="${tagWarnings}" var="tagWarning">
+						<br/><span>${tagWarning}</span>
+					</c:forEach>
+				</c:if>
 			</td>
 		</tr>
 		<tr>


### PR DESCRIPTION
HFE did not provide checks for obs used as set members and obsgroup (if the obsgroup concept was a set).
Added a mechanism to validate this and store concept ids violating this rule to FormEntryContext from where
they can be displayed on the HTML Form edit page.