### PR TITLE
HTML-646 merge HtmlFormEntry19Ext into HtmlFormEntry

### DIFF
--- a/api-tests/pom.xml
+++ b/api-tests/pom.xml
@@ -70,6 +70,10 @@
 			<version>1.1.0-alpha1</version>
 		</dependency>
 		<dependency>
+			<groupId>org.openmrs.module</groupId>
+			<artifactId>providermanagement-api</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.openmrs.test</groupId>
 			<artifactId>openmrs-test</artifactId>
 			<version>${openMRSVersion}</version>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -38,11 +38,16 @@
 			<artifactId>openmrs-web</artifactId>
 		</dependency>
 
+
 		<!-- jars we need to provide for compile but that will be provided at runtime 
 			(scope=provided) -->
 		<dependency>
 			<groupId>org.openmrs.module</groupId>
 			<artifactId>logic</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.openmrs.module</groupId>
+			<artifactId>providermanagement-api</artifactId>
 		</dependency>
 
 		<!-- jars required only to run test scripts (scope=test) -->

--- a/api/src/main/java/org/openmrs/module/htmlformentry/HtmlFormEntryActivator.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/HtmlFormEntryActivator.java
@@ -15,7 +15,9 @@ package org.openmrs.module.htmlformentry;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.openmrs.api.context.Context;
 import org.openmrs.module.BaseModuleActivator;
+import org.openmrs.module.htmlformentry.handler.EncounterProviderAndRoleTagHandler;
 
 /**
  * Contains the logic that is run every time HTML Form Entry module

--- a/api/src/main/java/org/openmrs/module/htmlformentry/element/ProviderAndRoleElement.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/element/ProviderAndRoleElement.java
@@ -1,0 +1,359 @@
+/**
+ * The contents of this file are subject to the OpenMRS Public License
+ * Version 1.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://license.openmrs.org
+ *
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
+ */
+package org.openmrs.module.htmlformentry.element;
+
+import org.openmrs.EncounterRole;
+import org.openmrs.Person;
+import org.openmrs.Provider;
+import org.openmrs.api.EncounterService;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.htmlformentry.BadFormDesignException;
+import org.openmrs.module.htmlformentry.FormEntryContext;
+import org.openmrs.module.htmlformentry.FormEntryContext.Mode;
+import org.openmrs.module.htmlformentry.FormEntrySession;
+import org.openmrs.module.htmlformentry.FormSubmissionError;
+import org.openmrs.module.htmlformentry.HtmlFormEntryUtil;
+import org.openmrs.module.htmlformentry.action.FormSubmissionControllerAction;
+import org.openmrs.module.htmlformentry.util.MatchMode;
+import org.openmrs.module.htmlformentry.widget.EncounterRoleWidget;
+import org.openmrs.module.htmlformentry.widget.ErrorWidget;
+import org.openmrs.module.htmlformentry.widget.ProviderAjaxAutoCompleteWidget;
+import org.openmrs.module.htmlformentry.widget.ProviderWidget;
+import org.openmrs.module.htmlformentry.widget.Widget;
+import org.springframework.util.StringUtils;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+
+/**
+ *
+ */
+public class ProviderAndRoleElement implements HtmlGeneratorElement, FormSubmissionControllerAction {
+
+	boolean required = false;
+    int count = 1;
+
+	EncounterRoleWidget roleWidget;
+	ErrorWidget roleErrorWidget;
+	List<Widget> providerWidgets = new ArrayList<Widget>();
+	List<ErrorWidget> providerErrorWidgets = new ArrayList<ErrorWidget>();
+	
+	// in case EncounterRole is specified as a parameter to the tag
+	EncounterRole encounterRole;
+
+    // Whether autocomplete or dropdown (default is dropdown)
+    private boolean autocompleteProvider = false;
+    private MatchMode providerMatchMode = null;
+
+    public ProviderAndRoleElement() {
+        // just used for testing, you should always initialize with the constructor below
+    }
+
+	/**
+     * @param parameters
+	 * @throws BadFormDesignException 
+     */
+    public ProviderAndRoleElement(FormEntryContext context, Map<String, String> parameters) throws BadFormDesignException {
+
+        if(parameters.containsKey("autocompleteProvider")) {
+            autocompleteProvider = Boolean.valueOf(parameters.get("autocompleteProvider"));
+            if(parameters.containsKey("providerMatchMode")) {
+                try {
+                    String value = parameters.get("providerMatchMode");
+                    if(value != null) {
+                        providerMatchMode = MatchMode.valueOf(value);
+                    }
+                }catch (IllegalArgumentException ie) {
+                    providerMatchMode = MatchMode.ANYWHERE;
+                }
+            }
+        }
+
+        if (parameters.containsKey("required")) {
+    		required = Boolean.valueOf(parameters.get("required"));
+        }
+        if (parameters.containsKey("count")) {
+            count = Integer.valueOf(parameters.get("count"));
+        }
+
+        // if there is an encounterRole specified, use that; otherwise create a roleWidget
+    	if (parameters.containsKey("encounterRole")) {
+    		EncounterService es = Context.getEncounterService();
+    		String param = parameters.get("encounterRole");
+    		try {
+    			encounterRole = es.getEncounterRole(Integer.valueOf(param));
+    		} catch (Exception ex) {
+    			encounterRole = es.getEncounterRoleByUuid(param);
+    		}
+    		if (encounterRole == null)
+    			throw new BadFormDesignException("Cannot find EncounterRole \"" + param + "\"");
+    		
+    	} else {
+    		roleWidget = new EncounterRoleWidget();
+    		roleErrorWidget = new ErrorWidget();
+    		context.registerWidget(roleWidget);
+    		context.registerErrorWidget(roleWidget, roleErrorWidget);
+    	}
+
+        boolean initialProviderSet = false;
+
+        if (encounterRole == null) {
+            if (count > 1) {
+                throw new BadFormDesignException("HTML Form Entry does not (yet) support multiple providers per " +
+                        "encounter without specifying encounter roles");
+            }
+
+            Widget providerWidget;
+            ErrorWidget providerErrorWidget;
+            if(!autocompleteProvider) {
+                // get the list of providers we want to use
+                List<Provider> providerList = getProviderList(parameters);
+
+                // handle the case where no encounterRole attribute is specified
+
+                providerWidget = new ProviderWidget();
+                ((ProviderWidget)providerWidget).setProviders(providerList);
+                providerErrorWidget = new ErrorWidget();
+
+
+            } else { //autocomplete provider
+                providerWidget = new ProviderAjaxAutoCompleteWidget();
+                if(providerMatchMode != null) {
+                    ((ProviderAjaxAutoCompleteWidget) providerWidget).setMatchMode(providerMatchMode);
+                }
+            }
+            providerErrorWidget = new ErrorWidget();
+            context.registerWidget(providerWidget);
+            context.registerErrorWidget(providerWidget, providerErrorWidget);
+            providerWidgets.add(providerWidget);
+            providerErrorWidgets.add(providerErrorWidget);
+
+                if (context.getExistingEncounter() != null) {
+                    Map<EncounterRole, Set<Provider>> byRoles = context.getExistingEncounter().getProvidersByRoles();
+                    if (byRoles.size() > 0) {
+                        // currently we only support a single provider in this mode
+                        if (byRoles.size() > 1 || byRoles.values().iterator().next().size() > 1) {
+                            throw new BadFormDesignException("HTML Form Entry does not (yet) support multiple " +
+                                    "providers per encounter without specifying encounter roles");
+                        }
+
+                        Entry<EncounterRole, Set<Provider>> roleAndProvider = byRoles.entrySet().iterator().next();
+                        Provider p = roleAndProvider.getValue().iterator().next();
+                        providerWidget.setInitialValue(p);
+                        initialProviderSet = true;
+                        roleWidget.setInitialValue(roleAndProvider.getKey());
+                    }
+                }
+        }
+        // handle the case where an encounter role is specified
+        else {
+
+            // get any existing providers for the specified role
+            List<Provider> byRole = null;
+            if (context.getExistingEncounter() != null) {
+                byRole = new ArrayList<Provider>(context.getExistingEncounter().getProvidersByRole(encounterRole));
+            }
+
+            // register the provider widgets, setting any existing provider values
+            if(!autocompleteProvider) {
+                List<Provider> providerList = getProviderList(parameters);
+                for (int currentIteration = 0; currentIteration < count; currentIteration++) {
+
+                    ProviderWidget providerWidget = new ProviderWidget();
+                    providerWidget.setProviders(providerList);
+                    ErrorWidget providerErrorWidget = new ErrorWidget();
+                    context.registerWidget(providerWidget);
+                    context.registerErrorWidget(providerWidget, providerErrorWidget);
+                    providerWidgets.add(providerWidget);
+                    providerErrorWidgets.add(providerErrorWidget);
+
+                    if (byRole != null && byRole.size() > currentIteration) {
+                        providerWidget.setInitialValue(byRole.get(currentIteration));
+                        initialProviderSet = true;
+                    }
+                }
+            }  else { //Handle autocomplete
+                for(int currentIteration = 0; currentIteration < count; currentIteration++) {
+                    Widget providerWidget = new ProviderAjaxAutoCompleteWidget();
+                    if(providerMatchMode != null) {
+                        ((ProviderAjaxAutoCompleteWidget) providerWidget).setMatchMode(providerMatchMode);
+                    }
+
+                    ErrorWidget providerErrorWidget = new ErrorWidget();
+                    context.registerWidget(providerWidget);
+                    context.registerErrorWidget(providerWidget,providerErrorWidget);
+
+                    providerWidgets.add(providerWidget);
+                    providerErrorWidgets.add(providerErrorWidget);
+
+                    if (byRole != null && byRole.size() > currentIteration) {
+                        providerWidget.setInitialValue(byRole.get(currentIteration));
+                        initialProviderSet = true;
+                    }
+                }
+            }
+        }
+
+        // set the default provider if no existing provider and a default is specified
+    	if (!initialProviderSet && providerWidgets.iterator().next() != null && StringUtils.hasText(parameters.get("default"))) {
+    		String temp = parameters.get("default");
+    		Provider provider = null;
+    		if ("currentUser".equals(temp)) {
+    			Person me = Context.getAuthenticatedUser().getPerson();
+    			Collection<Provider> candidates = Context.getProviderService().getProvidersByPerson(me);
+    			if (candidates.size() > 0)
+    				provider = candidates.iterator().next();
+    		} else {
+	    		try {
+	    			provider = Context.getProviderService().getProvider(Integer.valueOf(temp));
+	    		} catch (Exception ex) {
+	    			provider = Context.getProviderService().getProviderByUuid(temp);
+	    		}
+    		}
+    		if (provider != null) {
+    			providerWidgets.iterator().next().setInitialValue(provider);
+    		}
+    	}
+    }
+
+	/**
+     * @see org.openmrs.module.htmlformentry.element.HtmlGeneratorElement#generateHtml(org.openmrs.module.htmlformentry.FormEntryContext)
+     */
+    @Override
+    public String generateHtml(FormEntryContext context) {
+    	StringBuilder ret = new StringBuilder();
+    	if (roleWidget != null) {
+    		ret.append(roleWidget.generateHtml(context));
+    		if (context.getMode() != Mode.VIEW)
+    			ret.append(roleErrorWidget.generateHtml(context));
+    		ret.append(": ");
+    	}
+
+        Iterator<ErrorWidget> errorWidgetIterator = providerErrorWidgets.iterator();
+        for (Widget providerWidget : providerWidgets) {
+			ret.append(providerWidget.generateHtml(context));
+			if (context.getMode() != Mode.VIEW) {
+				ret.append(errorWidgetIterator.next().generateHtml(context));
+            }
+		}
+
+	    return ret.toString();
+    }
+    
+    /**
+     * @see org.openmrs.module.htmlformentry.action.FormSubmissionControllerAction#validateSubmission(org.openmrs.module.htmlformentry.FormEntryContext, javax.servlet.http.HttpServletRequest)
+     */
+    @Override
+    public Collection<FormSubmissionError> validateSubmission(FormEntryContext context, HttpServletRequest submission) {
+
+        if (!required) {
+    		return null;
+        }
+
+        EncounterRole role = encounterRole;
+    	Provider provider = null;
+    	List<FormSubmissionError> ret = new ArrayList<FormSubmissionError>();
+    	if (roleWidget != null) {
+    		role = (EncounterRole) roleWidget.getValue(context, submission);
+    		if (role == null)
+        		ret.add(new FormSubmissionError(roleWidget, Context.getMessageSourceService().getMessage("htmlformentry.error.required")));
+    	}
+
+        boolean atLeastOneProviderSpecified = false;
+
+        for (Widget providerWidget : providerWidgets) {
+            if (providerWidget != null) {
+                provider = (Provider) providerWidget.getValue(context, submission);
+                if (provider != null) {
+                    atLeastOneProviderSpecified = true;
+                }
+            }
+        }
+
+    	if (!atLeastOneProviderSpecified) {
+            ret.add(new FormSubmissionError(providerWidgets.get(0), Context.getMessageSourceService().getMessage("htmlformentry.error.required")));
+    	}
+    	return ret;
+    }
+
+	/**
+     * @see org.openmrs.module.htmlformentry.action.FormSubmissionControllerAction#handleSubmission(org.openmrs.module.htmlformentry.FormEntrySession, javax.servlet.http.HttpServletRequest)
+     */
+    @Override
+    public void handleSubmission(FormEntrySession session, HttpServletRequest submission) {
+
+        EncounterRole role = encounterRole;
+    	Provider provider = null;
+
+        if (roleWidget != null) {
+    		role = (EncounterRole) roleWidget.getValue(session.getContext(), submission);
+    	}
+
+        Set<Provider> currentProvidersForRole = session.getSubmissionActions().getCurrentEncounter().getProvidersByRole(role);
+
+        for (Widget providerWidget : providerWidgets) {
+    		provider = (Provider) providerWidget.getValue(session.getContext(), submission);
+
+            if (provider != null) {
+                // if this provider it not currently one of the provider, add her
+                if (currentProvidersForRole != null || !currentProvidersForRole.contains(provider)) {
+                    session.getSubmissionActions().getCurrentEncounter().addProvider(role, provider);
+                }
+                // we remove this provider so that we end up with a list of providers to void
+                currentProvidersForRole.remove(provider);
+            }
+        }
+
+        // now remove any current providers that we haven't found in the provider list
+        for (Provider providerToRemove : currentProvidersForRole) {
+            session.getSubmissionActions().getCurrentEncounter().removeProvider(role, providerToRemove);
+        }
+    }
+
+    protected List<Provider> getProviderList(Map<String, String> parameters)  throws BadFormDesignException {
+
+        List<Provider> providerList = new ArrayList<Provider>();
+
+        // if no provider roles specified, just return all (non-retired) providers
+        if (!parameters.containsKey("providerRoles")) {
+            providerList = Context.getProviderService().getAllProviders(false);
+        }
+        else {
+            // retrieve the provider roles referenced in the tag
+            List providerRoles = new ArrayList();
+
+            for (String providerRoleId : parameters.get("providerRoles").split(",")) {
+                Object providerRole = HtmlFormEntryUtil.getProviderRole(providerRoleId.trim());
+
+                if (providerRole == null) {
+                    throw new BadFormDesignException("No provider role found with id or uuid " + providerRoleId.trim());
+
+                }
+
+                providerRoles.add(providerRole);
+            }
+
+            providerList = HtmlFormEntryUtil.getProviders(providerRoles);
+        }
+
+        return providerList;
+    }
+}

--- a/api/src/main/java/org/openmrs/module/htmlformentry/element/ProviderStub.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/element/ProviderStub.java
@@ -1,0 +1,76 @@
+package org.openmrs.module.htmlformentry.element;
+
+import org.openmrs.Person;
+import org.openmrs.Provider;
+import org.springframework.util.StringUtils;
+
+public class ProviderStub extends ValueStub {
+    private Integer providerId;
+    private String identifier;
+    private String name;
+    private String uuid;
+
+    public ProviderStub(Provider provider) {
+        if(provider != null) {
+            setId(provider.getProviderId());
+            this.providerId = provider.getProviderId();
+            this.identifier = provider.getIdentifier();
+            if (StringUtils.hasLength(provider.getName())) {
+                this.name = provider.getName();
+            } else {
+                //Use person names if they exist.
+                Person p = provider.getPerson();
+                if (p != null) {
+                    this.name = p.getGivenName() + " " + p.getFamilyName() + ", " + p.getMiddleName();
+                }
+            }
+            this.uuid = provider.getUuid();
+        }
+    }
+
+    public Integer getProviderId() {
+        return providerId;
+    }
+
+    public void setProviderId(Integer providerId) {
+        this.providerId = providerId;
+    }
+
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public void setIdentifier(String identifier) {
+        this.identifier = identifier;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getUuid() {
+        return uuid;
+    }
+
+    public void setUuid(String uuid) {
+        this.uuid = uuid;
+    }
+
+    @Override
+    public String getDisplayValue() {
+        return name + (StringUtils.hasLength(identifier)? " ("+identifier+")" : "");
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if(o != null && o instanceof ProviderStub){
+            ProviderStub other = (ProviderStub)o;
+            return this.getProviderId().intValue() == other.getProviderId().intValue();
+        }
+        return false;
+    }
+}

--- a/api/src/main/java/org/openmrs/module/htmlformentry/handler/EncounterProviderAndRoleTagHandler.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/handler/EncounterProviderAndRoleTagHandler.java
@@ -1,0 +1,54 @@
+/**
+ * The contents of this file are subject to the OpenMRS Public License
+ * Version 1.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://license.openmrs.org
+ *
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
+ */
+package org.openmrs.module.htmlformentry.handler;
+
+import org.openmrs.EncounterRole;
+import org.openmrs.Provider;
+import org.openmrs.module.htmlformentry.BadFormDesignException;
+import org.openmrs.module.htmlformentry.FormEntrySession;
+import org.openmrs.module.htmlformentry.FormSubmissionController;
+import org.openmrs.module.htmlformentry.element.ProviderAndRoleElement;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+
+/**
+ * Handles the <encounterProviderAndRole, for the new {@link Provider} model in OpenMRS 1.9+
+ */
+public class EncounterProviderAndRoleTagHandler extends SubstitutionTagHandler {
+
+	@Override
+    protected List<AttributeDescriptor> createAttributeDescriptors() {
+		List<AttributeDescriptor> attributeDescriptors = new ArrayList<AttributeDescriptor>();
+		attributeDescriptors.add(new AttributeDescriptor("default", Provider.class));
+		attributeDescriptors.add(new AttributeDescriptor("encounterRole", EncounterRole.class));
+		return Collections.unmodifiableList(attributeDescriptors);
+	}
+	
+	/**
+	 * @see org.openmrs.module.htmlformentry.handler.SubstitutionTagHandler#getSubstitution(org.openmrs.module.htmlformentry.FormEntrySession, org.openmrs.module.htmlformentry.FormSubmissionController, java.util.Map)
+     * @throws BadFormDesignException 
+     */
+    @Override
+    protected String getSubstitution(FormEntrySession session, FormSubmissionController controllerActions,
+                                     Map<String, String> parameters) throws BadFormDesignException {
+	    ProviderAndRoleElement element = new ProviderAndRoleElement(session.getContext(), parameters);
+	    session.getSubmissionController().addAction(element);
+	    return element.generateHtml(session.getContext());
+    }
+	
+}

--- a/api/src/main/java/org/openmrs/module/htmlformentry/util/MatchMode.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/util/MatchMode.java
@@ -1,0 +1,5 @@
+package org.openmrs.module.htmlformentry.util;
+
+public enum MatchMode {
+    START, ANYWHERE, END;
+}

--- a/api/src/main/java/org/openmrs/module/htmlformentry/util/Predicate.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/util/Predicate.java
@@ -1,0 +1,5 @@
+package org.openmrs.module.htmlformentry.util;
+
+public interface Predicate<T> {
+    boolean test(T t);
+}

--- a/api/src/main/java/org/openmrs/module/htmlformentry/util/ProviderTransformer.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/util/ProviderTransformer.java
@@ -1,0 +1,19 @@
+package org.openmrs.module.htmlformentry.util;
+
+import org.openmrs.Provider;
+import org.openmrs.module.htmlformentry.element.ProviderStub;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class ProviderTransformer implements Transformer<Provider,ProviderStub> {
+    @Override
+    public Collection<ProviderStub> transform(Collection<Provider> collection, Predicate<Provider> predicate) {
+        List<ProviderStub> providerStubs = new ArrayList<ProviderStub>();
+        for(Provider p:collection) {
+            if(predicate.test(p)) providerStubs.add(new ProviderStub(p));
+        }
+        return providerStubs;
+    }
+}

--- a/api/src/main/java/org/openmrs/module/htmlformentry/util/Transformer.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/util/Transformer.java
@@ -1,0 +1,7 @@
+package org.openmrs.module.htmlformentry.util;
+
+import java.util.Collection;
+
+public interface Transformer<T,V> {
+    Collection<V>  transform(Collection<T> collection,Predicate<T> predicate);
+}

--- a/api/src/main/java/org/openmrs/module/htmlformentry/widget/EncounterRoleWidget.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/widget/EncounterRoleWidget.java
@@ -1,0 +1,91 @@
+/**
+ * The contents of this file are subject to the OpenMRS Public License
+ * Version 1.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://license.openmrs.org
+ *
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
+ */
+package org.openmrs.module.htmlformentry.widget;
+
+import org.openmrs.EncounterRole;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.htmlformentry.FormEntryContext;
+import org.openmrs.module.htmlformentry.FormEntryContext.Mode;
+import org.springframework.util.StringUtils;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+
+/**
+ * Widget that lets you choose an {@link EncounterRole} from a dropdown.
+ */
+public class EncounterRoleWidget implements Widget {
+	
+	private EncounterRole initialValue;
+	
+	/**
+	 * @see org.openmrs.module.htmlformentry.widget.Widget#setInitialValue(java.lang.Object)
+	 */
+	@Override
+	public void setInitialValue(Object initialValue) {
+		this.initialValue = (EncounterRole) initialValue;
+	}
+
+	/**
+	 * @see org.openmrs.module.htmlformentry.widget.Widget#generateHtml(org.openmrs.module.htmlformentry.FormEntryContext)
+	 */
+	@Override
+	public String generateHtml(FormEntryContext context) {
+		if (context.getMode() == Mode.VIEW) {
+            if (initialValue != null)
+                return WidgetFactory.displayValue(initialValue.getName());
+            else
+                return "";
+        }
+
+		List<EncounterRole> roles = Context.getEncounterService().getAllEncounterRoles(true);
+        Collections.sort(roles, new Comparator<EncounterRole>() {
+			@Override
+            public int compare(EncounterRole left, EncounterRole right) {
+	            return left.getName().compareTo(right.getName());
+            }
+        });
+		
+		StringBuilder sb = new StringBuilder();
+        sb.append("<select name=\"" + context.getFieldName(this) + "\">");
+        sb.append("\n<option value=\"\">");
+        sb.append(Context.getMessageSourceService().getMessage("htmlformentry.chooseAnEncounterRole"));
+        sb.append("</option>");
+        
+        for (EncounterRole role : roles) {
+        	sb.append("\n<option ");
+        	if (initialValue != null && initialValue.equals(role))
+        		sb.append("selected=\"true\" ");
+        	sb.append("value=\"" + role.getId() + "\">").append(role.getName()).append("</option>");
+        }
+        sb.append("</select>");
+		return sb.toString();
+	}
+	
+	/**
+	 * @see org.openmrs.module.htmlformentry.widget.Widget#getValue(org.openmrs.module.htmlformentry.FormEntryContext, javax.servlet.http.HttpServletRequest)
+	 */
+	@Override
+	public Object getValue(FormEntryContext context, HttpServletRequest request) {
+		String val = request.getParameter(context.getFieldName(this));
+        if (StringUtils.hasText(val)) {
+        	return Context.getEncounterService().getEncounterRole(Integer.valueOf(val));
+        }
+        return null;
+	}
+	
+}

--- a/api/src/main/java/org/openmrs/module/htmlformentry/widget/ProviderAjaxAutoCompleteWidget.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/widget/ProviderAjaxAutoCompleteWidget.java
@@ -1,0 +1,143 @@
+package org.openmrs.module.htmlformentry.widget;
+
+import org.openmrs.Provider;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.htmlformentry.FormEntryContext;
+import org.openmrs.module.htmlformentry.element.ProviderStub;
+import org.openmrs.module.htmlformentry.util.MatchMode;
+import org.springframework.util.StringUtils;
+
+import javax.servlet.http.HttpServletRequest;
+
+public class ProviderAjaxAutoCompleteWidget implements Widget {
+
+    private MatchMode matchMode = MatchMode.START;
+
+    private Provider initialValue;
+    private final String SRC = "providers";
+
+    public MatchMode getMatchMode() {
+        return matchMode;
+    }
+
+    public void setMatchMode(MatchMode matchMode) {
+        if(matchMode == null) this.matchMode = MatchMode.ANYWHERE;
+        else this.matchMode = matchMode;
+    }
+
+    @Override
+    public void setInitialValue(Object initialValue) {
+         this.initialValue = (Provider)initialValue;
+    }
+
+    @Override
+    public String generateHtml(FormEntryContext context) {
+
+        StringBuilder sb = new StringBuilder();
+        if (context.getMode().equals(FormEntryContext.Mode.VIEW)) {
+            String toPrint = "";
+            if (initialValue != null) {
+                toPrint = initialValue.getName();
+                return WidgetFactory.displayValue(toPrint);
+            } else {
+                return WidgetFactory.displayEmptyValue("___________");
+            }
+        } else {
+            String placeholder = Context.getMessageSourceService().getMessage("htmlformentry.providerPlaceHolder");
+            sb.append("<input type=\"text\"  id=\""
+                    + context.getFieldName(this) + "\"" + " name=\""
+                    + context.getFieldName(this) + "\" "
+                    + " onfocus=\"setupProviderAutocomplete(this, '" + this.SRC + "');\""
+                    + " class=\"autoCompleteText\""
+                    + " onchange=\"setValWhenAutocompleteFieldBlanked(this)\""
+                    + " onblur=\"onBlurAutocomplete(this)\""
+                    + " placeholder = \"" + placeholder + "\"");
+
+            if (initialValue != null)
+                sb.append(" value=\"" + (new ProviderStub(initialValue).getDisplayValue()) + "\"");
+            sb.append("/>\n");
+
+            //Add hidden field for provider match mode
+            sb.append("<input type='hidden' id='").append(context.getFieldName(this)+"_matchMode_hid'").
+                    append(" value='").append(matchMode).append("' />\n");
+
+            sb.append("<input name=\"" + context.getFieldName(this) + "_hid"
+                    + "\" id=\"" + context.getFieldName(this) + "_hid" + "\""
+                    + " type=\"hidden\" class=\"autoCompleteHidden\" ");
+            if (initialValue != null) {
+                sb.append(" value=\"" + initialValue.getProviderId() + "\"");
+            }
+            sb.append("/> \n");
+        }
+        sb.append(createJsAutoCompleteFunction());
+
+        return sb.toString();
+    }
+
+    @Override
+    public Object getValue(FormEntryContext context, HttpServletRequest request) {
+        String value = request.getParameter(context.getFieldName(this)+"_hid");
+        Provider provider = null;
+        if(StringUtils.hasText(value)) {
+            provider = Context.getProviderService().getProvider(Integer.valueOf(value));
+        }
+        return provider;
+    }
+
+    private String createJsAutoCompleteFunction() {
+        StringBuilder sb = new StringBuilder("<script type=\"text/javascript\">\n");
+        sb.append("function setupProviderAutocomplete(element,src) {");
+        sb.append("    var hiddenField = jQuery(\"#\"+element.id+\"_hid\");\n");
+        sb.append("    var textField = jQuery(element); \n");
+        sb.append("    var providerMatchMode = jQuery(\"#\"+element.id+\"_matchMode_hid\"); \n");
+        sb.append("    var select = false;");
+
+        sb.append("    var req = { 'searchParam': textField.val()};\n");
+
+        sb.append("    if (hiddenField.length > 0 && textField.length > 0) { \n");
+        sb.append("        textField.autocomplete( { \n");
+        sb.append("          source: function(req, add){ \n");
+        sb.append("            //pass request to server  \n");
+
+        sb.append("            jQuery.getJSON(location.protocol + '//' + location.host + getContextPath() + " +
+                "'/ws/module/htmlformentry/' + src ," +
+                "{\"searchParam\":textField.val(), 'matchMode':providerMatchMode.val()}, function(data) { \n");
+
+        sb.append("                //create array for response objects \n");
+        sb.append("                var suggestions = [];");
+        sb.append("                jQuery.each(data,function(i,val){ \n");
+        sb.append("                    var item = {}; ");
+        sb.append("                    item.label = val.displayValue; \n");
+        sb.append("                   item.value = val.providerId; \n");
+        sb.append("                    suggestions.push(item);  \n");
+        sb.append("                }); \n");
+
+        sb.append("\n");
+        sb.append("                if (suggestions.length==0) { \n");
+        sb.append("                     hiddenField.val(''); \n");
+        sb.append("                     textField.css('color','red'); \n");
+        sb.append("                } \n");
+        sb.append("                add(suggestions);  \n");
+        sb.append("            }); \n");
+        sb.append("        }, \n");
+
+        sb.append("        minLength: 2, \n");
+        sb.append("        focus: function(event, ui) {\n");
+        sb.append("             textField.val(ui.item.label);\n");
+        sb.append("             return false;\n");
+        sb.append("         }, \n");
+        sb.append("        select: function(event, ui) {\n");
+        sb.append("            hiddenField.val(ui.item.value); \n");
+        sb.append("            textField.val(ui.item.label); \n");
+        sb.append("            textField.css('color','black') \n");
+        sb.append("            select = true; \n");
+        sb.append("            return false; \n");
+        sb.append("        }  \n");
+        sb.append("      });  \n");
+        sb.append("    }   \n");
+        sb.append("} \n");
+        sb.append("</script>\n");
+
+        return sb.toString();
+    }
+}

--- a/api/src/main/java/org/openmrs/module/htmlformentry/widget/ProviderWidget.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/widget/ProviderWidget.java
@@ -1,0 +1,96 @@
+/**
+ * The contents of this file are subject to the OpenMRS Public License
+ * Version 1.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://license.openmrs.org
+ *
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
+ */
+package org.openmrs.module.htmlformentry.widget;
+
+import org.openmrs.Provider;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.htmlformentry.FormEntryContext;
+import org.openmrs.module.htmlformentry.FormEntryContext.Mode;
+import org.openmrs.module.htmlformentry.HtmlFormEntryUtil;
+import org.openmrs.util.ProviderByPersonNameComparator;
+import org.springframework.util.StringUtils;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+
+/**
+ * Widget that lets you choose a {@link Provider} from a dropdown
+ */
+public class ProviderWidget implements Widget {
+	
+	private Provider initialValue;
+
+    private List<Provider> providers = new ArrayList<Provider>();
+	
+	/**
+	 * @see org.openmrs.module.htmlformentry.widget.Widget#setInitialValue(java.lang.Object)
+	 */
+	@Override
+	public void setInitialValue(Object initialValue) {
+		this.initialValue = (Provider) initialValue;
+	}
+
+    public void setProviders(List<Provider> providers) {
+        this.providers = providers;
+    }
+
+    /**
+	 * @see org.openmrs.module.htmlformentry.widget.Widget#generateHtml(org.openmrs.module.htmlformentry.FormEntryContext)
+	 */
+	@Override
+	public String generateHtml(FormEntryContext context) {
+		if (context.getMode() == Mode.VIEW) {
+            if (initialValue != null)
+                return WidgetFactory.displayValue(initialValue.getName());
+            else
+                return "";
+        }
+
+		Collections.sort(providers, new ProviderByPersonNameComparator());
+
+		StringBuilder sb = new StringBuilder();
+        sb.append("<select name=\"" + context.getFieldName(this) + "\">");
+        sb.append("\n<option value=\"\">");
+        sb.append(Context.getMessageSourceService().getMessage("htmlformentry.chooseAProvider"));
+        sb.append("</option>");
+
+        for (Provider provider : providers) {
+        	sb.append("\n<option ");
+        	if (initialValue != null && initialValue.equals(provider))
+        		sb.append("selected=\"true\" ");
+        	sb.append("value=\"" + provider.getId() + "\">").append(provider.getPerson() != null ?
+                    HtmlFormEntryUtil.getFullNameWithFamilyNameFirst(provider.getPerson().getPersonName()) :
+                    provider.getName())
+                    .append("</option>");
+        }
+        sb.append("</select>");
+		return sb.toString();
+	}
+
+	/**
+	 * @see org.openmrs.module.htmlformentry.widget.Widget#getValue(org.openmrs.module.htmlformentry.FormEntryContext, HttpServletRequest)
+	 */
+	@Override
+	public Object getValue(FormEntryContext context, HttpServletRequest request) {
+		String val = request.getParameter(context.getFieldName(this));
+        if (StringUtils.hasText(val)) {
+        	return Context.getProviderService().getProvider(Integer.valueOf(val));
+        }
+        return null;
+	}
+	
+}

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -88,3 +88,10 @@ htmlformentry.error.notAnInteger                        = Not an integer
 htmlformentry.error.notLessThan                         = Cannot be less than
 htmlformentry.error.notGreaterThan                      = Cannot be greater than
 
+htmlformentry.chooseAnEncounterRole=Choose an Encounter Role
+htmlformentry.unknownProviderName=Unknown
+htmlformentry.providerPlaceHolder=Type identifier or name
+
+
+
+

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -30,6 +30,10 @@
                             <bean class="org.openmrs.module.htmlformentry.handler.WhenTagHandler"></bean>
                         </entry>
                         <entry>
+                            <key><value>encounterProviderAndRole</value></key>
+                            <bean class="org.openmrs.module.htmlformentry.handler.EncounterProviderAndRoleTagHandler"/>
+                        </entry>
+                        <entry>
                             <key><value>obsgroup</value></key>
                             <bean class="org.openmrs.module.htmlformentry.handler.ObsGroupTagHandler"/>
                         </entry>

--- a/api/src/test/java/org/openmrs/module/htmlformentry/EncounterProviderAndRoleTagTest.java
+++ b/api/src/test/java/org/openmrs/module/htmlformentry/EncounterProviderAndRoleTagTest.java
@@ -1,0 +1,488 @@
+/**
+ * The contents of this file are subject to the OpenMRS Public License
+ * Version 1.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://license.openmrs.org
+ *
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
+ */
+package org.openmrs.module.htmlformentry;
+
+import junit.framework.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.openmrs.Encounter;
+import org.openmrs.EncounterRole;
+import org.openmrs.Provider;
+import org.openmrs.api.context.Context;
+import org.openmrs.test.BaseModuleContextSensitiveTest;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+
+/**
+ * Integration test for the <encounterProviderAndRole/> tag 
+ */
+public class EncounterProviderAndRoleTagTest extends BaseModuleContextSensitiveTest {
+
+	@Before
+	public void setup() throws Exception {
+		executeDataSet("org/openmrs/module/htmlformentry/include/encounterProviderAndRole.xml");
+		new HtmlFormEntryActivator().started();
+	}
+	
+	@Test
+	public void encounterProviderAndRole_testPlainTag() throws Exception {
+		final Date date = new Date();
+		new RegressionTestHelper() {
+			
+			@Override
+			protected String getXmlDatasetPath() {
+				return "org/openmrs/module/htmlformentry/include/";
+			}
+			
+			@Override
+            public String getFormName() {
+				return "plainEncounterProviderAndRoleTag";
+			}
+						
+			@Override
+			public String[] widgetLabels() {
+				return new String[] { "Date:", "Location:", "ProviderAndRole:", "ProviderAndRole:!!1"};
+			}
+			
+			@Override
+			public void setupRequest(MockHttpServletRequest request, Map<String, String> widgets) {
+				request.addParameter(widgets.get("Date:"), dateAsString(date));
+				request.addParameter(widgets.get("Location:"), "2");
+				request.addParameter(widgets.get("ProviderAndRole:"), "3"); // encounter role
+				request.addParameter(widgets.get("ProviderAndRole:!!1"), "2"); // provider
+			}
+			
+			@Override
+			public void testResults(SubmissionResults results) {
+				results.assertNoErrors();
+				results.assertEncounterCreated();
+				results.assertLocation(2);
+				Map<EncounterRole, Set<Provider>> byRoles = results.getEncounterCreated().getProvidersByRoles();
+				Assert.assertEquals(1, byRoles.size());
+				EncounterRole encRole = byRoles.keySet().iterator().next();
+				Assert.assertEquals(Integer.valueOf(3), encRole.getEncounterRoleId());
+				Assert.assertEquals(Integer.valueOf(2), byRoles.get(encRole).iterator().next().getProviderId());
+			}
+		}.run();
+	}
+
+    @Test
+    public void encounterProviderAndRole_testTagWithRequiredAttribute() throws Exception {
+        final Date date = new Date();
+        new RegressionTestHelper() {
+
+            @Override
+            protected String getXmlDatasetPath() {
+                return "org/openmrs/module/htmlformentry/include/";
+            }
+
+            @Override
+            public String getFormName() {
+                return "requiredEncounterProviderAndRoleTag";
+            }
+
+            @Override
+            public String[] widgetLabels() {
+                return new String[] { "Date:", "Location:", "ProviderAndRole:", "ProviderAndRole:!!1"};
+            }
+
+            @Override
+            public void setupRequest(MockHttpServletRequest request, Map<String, String> widgets) {
+                request.addParameter(widgets.get("Date:"), dateAsString(date));
+                request.addParameter(widgets.get("Location:"), "2");
+                request.addParameter(widgets.get("ProviderAndRole:"), "3"); // encounter role
+                request.addParameter(widgets.get("ProviderAndRole:!!1"), "2"); // provider
+            }
+
+            @Override
+            public void testResults(SubmissionResults results) {
+                results.assertNoErrors();
+                results.assertEncounterCreated();
+                results.assertLocation(2);
+                Map<EncounterRole, Set<Provider>> byRoles = results.getEncounterCreated().getProvidersByRoles();
+                Assert.assertEquals(1, byRoles.size());
+                EncounterRole encRole = byRoles.keySet().iterator().next();
+                Assert.assertEquals(Integer.valueOf(3), encRole.getEncounterRoleId());
+                Assert.assertEquals(Integer.valueOf(2), byRoles.get(encRole).iterator().next().getProviderId());
+            }
+        }.run();
+    }
+
+    @Test(expected = AssertionError.class)
+    public void encounterProviderAndRole_testTagWithRequiredAttribute_shouldThrowExceptionIfNoProvider() throws Exception {
+        final Date date = new Date();
+        new RegressionTestHelper() {
+
+            @Override
+            protected String getXmlDatasetPath() {
+                return "org/openmrs/module/htmlformentry/include/";
+            }
+
+            @Override
+            public String getFormName() {
+                return "requiredEncounterProviderAndRoleTag";
+            }
+
+            @Override
+            public String[] widgetLabels() {
+                return new String[] { "Date:", "Location:", "ProviderAndRole:", "ProviderAndRole:!!1"};
+            }
+
+            @Override
+            public void setupRequest(MockHttpServletRequest request, Map<String, String> widgets) {
+                request.addParameter(widgets.get("Date:"), dateAsString(date));
+                request.addParameter(widgets.get("Location:"), "2");
+                request.addParameter(widgets.get("ProviderAndRole:"), "3"); // encounter role
+            }
+
+            @Override
+            public void testResults(SubmissionResults results) {
+                results.assertNoErrors();
+                results.assertEncounterCreated();
+                results.assertLocation(2);
+                Map<EncounterRole, Set<Provider>> byRoles = results.getEncounterCreated().getProvidersByRoles();
+                Assert.assertEquals(1, byRoles.size());
+                EncounterRole encRole = byRoles.keySet().iterator().next();
+                Assert.assertEquals(Integer.valueOf(3), encRole.getEncounterRoleId());
+                Assert.assertEquals(Integer.valueOf(2), byRoles.get(encRole).iterator().next().getProviderId());
+            }
+        }.run();
+    }
+
+
+    @Test
+	public void encounterProviderAndRole_testDefaultValue() throws Exception {
+		new RegressionTestHelper() {
+			
+			@Override
+			protected String getXmlDatasetPath() {
+				return "org/openmrs/module/htmlformentry/include/";
+			}
+			
+			@Override
+            public String getFormName() {
+				return "encounterProviderAndRoleTagWithDefault";
+			}
+
+			@Override
+			public void testBlankFormHtml(String html) {
+				Assert.assertTrue(html.contains("<option selected=\"true\" value=\"2\">"));
+			};
+		}.run();
+	}
+    @Test
+    public void encounterProviderAndRole_WithMultipleDropdownsOnlySetsOneToDefault() throws Exception {
+        new RegressionTestHelper() {
+
+            @Override
+            protected String getXmlDatasetPath() {
+                return "org/openmrs/module/htmlformentry/include/";
+            }
+
+            @Override
+            public String getFormName() {
+                return "encounterProviderAndRoleTagWithMultipleAndDefault";
+            }
+
+            @Override
+            public void testBlankFormHtml(String html) {
+                Assert.assertTrue(html.contains("<option selected=\"true\" value=\"2\">"));
+                Assert.assertTrue(html.contains("<option value=\"2\">"));
+            };
+        }.run();
+    }
+
+	
+	@Test
+	public void encounterProviderAndRole_testTagSpecifyingEncounterProviderTwiceWithDifferentRoles() throws Exception {
+		final Date date = new Date();
+		new RegressionTestHelper() {
+			
+			@Override
+			protected String getXmlDatasetPath() {
+				return "org/openmrs/module/htmlformentry/include/";
+			}
+			
+			@Override
+            public String getFormName() {
+				return "specifyingEncounterRoleTwiceWithDifferentRoles";
+			}
+						
+			@Override
+			public String[] widgetLabels() {
+				return new String[] { "Date:", "Location:", "Doctor:", "Nurse:" };
+			}
+			
+			@Override
+			public void setupRequest(MockHttpServletRequest request, Map<String, String> widgets) {
+				request.addParameter(widgets.get("Date:"), dateAsString(date));
+				request.addParameter(widgets.get("Location:"), "2");
+				request.addParameter(widgets.get("Doctor:"), "2"); // Doctor Bob
+				request.addParameter(widgets.get("Nurse:"), "1"); // Superuser
+			}
+					
+			@Override
+			public void testResults(SubmissionResults results) {
+				results.assertNoErrors();
+				results.assertEncounterCreated();
+				results.assertLocation(2);
+				Map<EncounterRole, Set<Provider>> byRoles = results.getEncounterCreated().getProvidersByRoles();
+				Assert.assertEquals(2, byRoles.size());
+				Set<Provider> doctors = byRoles.get(Context.getEncounterService().getEncounterRole(3));
+				Set<Provider> nurses = byRoles.get(Context.getEncounterService().getEncounterRole(2));
+				Assert.assertEquals(1, doctors.size());
+				Assert.assertEquals(1, nurses.size());
+				Assert.assertEquals(2, (int) doctors.iterator().next().getProviderId());
+				Assert.assertEquals(1, (int) nurses.iterator().next().getProviderId());
+			}
+			
+			@Override
+			public boolean doViewEncounter() {
+				return true;
+			}
+			
+			@Override
+			public void testViewingEncounter(Encounter encounter, String html) {
+				TestUtil.assertFuzzyEquals("Date:" + Context.getDateFormat().format(date) + " Location:Xanadu Doctor:Doctor Bob, M.D. Nurse:Super User", html);
+			}
+			
+		}.run();
+	}
+
+    @Test
+    public void encounterProviderAndRole_testTagSpecifyingEncounterProviderTwiceWithSameRole() throws Exception {
+        final Date date = new Date();
+        new RegressionTestHelper() {
+
+            @Override
+            protected String getXmlDatasetPath() {
+                return "org/openmrs/module/htmlformentry/include/";
+            }
+
+            @Override
+            public String getFormName() {
+                return "specifyingEncounterRoleTwiceWithSameRole";
+            }
+
+            @Override
+            public String[] widgetLabels() {
+                return new String[] { "Date:", "Location:", "Doctors:", "Doctors:!!1" };
+            }
+
+            @Override
+            public void setupRequest(MockHttpServletRequest request, Map<String, String> widgets) {
+                request.addParameter(widgets.get("Date:"), dateAsString(date));
+                request.addParameter(widgets.get("Location:"), "2");
+                request.addParameter(widgets.get("Doctors:"), "2"); // Doctor Bob
+                request.addParameter(widgets.get("Doctors:!!1"), "1"); // Superuser  (hack to reference by widget id, but no label for this widget
+            }
+
+            @Override
+            public void testResults(SubmissionResults results) {
+                results.assertNoErrors();
+                results.assertEncounterCreated();
+                results.assertLocation(2);
+
+                Map<EncounterRole, Set<Provider>> byRoles = results.getEncounterCreated().getProvidersByRoles();
+                Assert.assertEquals(1, byRoles.size());
+
+                Set<Provider> doctors = byRoles.get(Context.getEncounterService().getEncounterRole(3));
+                Assert.assertEquals(2, doctors.size());
+
+                // we can't guarantee the order of providers, but make sure both providers are now present
+                Set<Integer> providerIds = new HashSet<Integer>();
+                for (Provider doctor : doctors) {
+                    providerIds.add(doctor.getId());
+                }
+                Assert.assertEquals(2, providerIds.size());
+                Assert.assertTrue(providerIds.contains(1));
+                Assert.assertTrue(providerIds.contains(2));
+            }
+
+            @Override
+            public boolean doViewEncounter() {
+                return true;
+            }
+
+            @Override
+            public void testViewingEncounter(Encounter encounter, String html) {
+                TestUtil.assertFuzzyContains("Doctor Bob", html);
+                TestUtil.assertFuzzyContains("Super User", html);
+            }
+
+        }.run();
+    }
+
+    @Test
+    public void encounterProviderAndRole_testSpecifyingASingleProviderForTagThatAcceptsTwo() throws Exception {
+        final Date date = new Date();
+        new RegressionTestHelper() {
+
+            @Override
+            protected String getXmlDatasetPath() {
+                return "org/openmrs/module/htmlformentry/include/";
+            }
+
+            @Override
+            public String getFormName() {
+                return "specifyingEncounterRoleTwiceWithSameRole";
+            }
+
+            @Override
+            public String[] widgetLabels() {
+                return new String[] { "Date:", "Location:", "Doctors:" };
+            }
+
+            @Override
+            public void setupRequest(MockHttpServletRequest request, Map<String, String> widgets) {
+                request.addParameter(widgets.get("Date:"), dateAsString(date));
+                request.addParameter(widgets.get("Location:"), "2");
+                request.addParameter(widgets.get("Doctors:"), "2"); // Doctor Bob
+            }
+
+            @Override
+            public void testResults(SubmissionResults results) {
+                results.assertNoErrors();
+                results.assertEncounterCreated();
+                results.assertLocation(2);
+
+                Map<EncounterRole, Set<Provider>> byRoles = results.getEncounterCreated().getProvidersByRoles();
+                Assert.assertEquals(1, byRoles.size());
+
+                Set<Provider> doctors = byRoles.get(Context.getEncounterService().getEncounterRole(3));
+                Assert.assertEquals(1, doctors.size());
+                Assert.assertEquals(new Integer(2), doctors.iterator().next().getId());
+            }
+
+            @Override
+            public boolean doViewEncounter() {
+                return true;
+            }
+
+            @Override
+            public void testViewingEncounter(Encounter encounter, String html) {
+                TestUtil.assertFuzzyContains("Doctor Bob", html);
+                TestUtil.assertFuzzyDoesNotContain("Super User", html);
+            }
+
+        }.run();
+    }
+
+    @Test
+    public void encounterProviderAndRole_testRemovingProviderFromEncounter() throws Exception {
+        final Date date = new Date();
+        new RegressionTestHelper() {
+
+            @Override
+            protected String getXmlDatasetPath() {
+                return "org/openmrs/module/htmlformentry/include/";
+            }
+
+            @Override
+            public String getFormName() {
+                return "specifyingEncounterRoleTwiceWithSameRole";
+            }
+
+            @Override
+            public String[] widgetLabels() {
+                return new String[] { "Date:", "Location:", "Doctors:", "Doctors:!!1" };
+            }
+
+            @Override
+            public void setupRequest(MockHttpServletRequest request, Map<String, String> widgets) {
+
+                // first set two providers
+                request.addParameter(widgets.get("Date:"), dateAsString(date));
+                request.addParameter(widgets.get("Location:"), "2");
+                request.addParameter(widgets.get("Doctors:"), "2"); // Doctor Bob
+                request.addParameter(widgets.get("Doctors:!!1"), "1"); // Superuser
+
+            }
+
+            @Override
+            public boolean doEditEncounter() {
+                return true;
+            }
+
+            @Override
+            public String[] widgetLabelsForEdit() {
+                return new String[] { "Date:", "Location:", "Doctors:", "Doctors:!!1" };
+            }
+
+            @Override
+            public void setupEditRequest(MockHttpServletRequest request, Map<String, String> widgets) {
+                // now, in the edit request, only set a single provider
+                request.setParameter(widgets.get("Doctors:"), "1"); // Superuser
+                request.setParameter(widgets.get("Doctors:!!1"), ""); // set the second doctor field blank
+            }
+
+            @Override
+            public void testEditedResults(SubmissionResults results) {
+                results.assertNoErrors();
+                results.assertLocation(2);
+
+                Map<EncounterRole, Set<Provider>> byRoles = results.getEncounterCreated().getProvidersByRoles();
+                Assert.assertEquals(1, byRoles.size());
+
+                Set<Provider> doctors = byRoles.get(Context.getEncounterService().getEncounterRole(3));
+                Assert.assertEquals(1, doctors.size());
+
+                Assert.assertEquals(1, doctors.size());
+                Assert.assertEquals(new Integer(1), doctors.iterator().next().getId());
+            }
+        }.run();
+    }
+
+    // TODO: figure out why this tests is failing on bamboo and re-enable!
+
+    @Test
+    @Ignore
+    public void encounterProviderAndRole_testWithProviderRoleAttribute() throws Exception {
+
+        // load the provider role specific test dataset
+        executeDataSet("org/openmrs/module/htmlformentry/include/providerRoles-dataset.xml");
+
+        final Date date = new Date();
+        new RegressionTestHelper() {
+
+            @Override
+            protected String getXmlDatasetPath() {
+                return "org/openmrs/module/htmlformentry/include/";
+            }
+
+            @Override
+            public String getFormName() {
+                return "encounterProviderAndRoleTagWithProviderRolesAttribute";
+            }
+
+            @Override
+            public void testBlankFormHtml(String html) {
+                TestUtil.assertFuzzyContains("Mr. Horatio Test Hornblower", html);
+                TestUtil.assertFuzzyContains("Johnny Test Doe", html);
+                TestUtil.assertFuzzyContains("Collet Test Chebaskwony", html);
+
+                TestUtil.assertFuzzyDoesNotContain("Anet Test Oloo", html);
+            }
+
+        }.run();
+    }
+
+
+}

--- a/api/src/test/java/org/openmrs/module/htmlformentry/HtmlFormEntryUtilComponentTest.java
+++ b/api/src/test/java/org/openmrs/module/htmlformentry/HtmlFormEntryUtilComponentTest.java
@@ -1,0 +1,109 @@
+package org.openmrs.module.htmlformentry;
+
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.openmrs.Provider;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.providermanagement.ProviderRole;
+import org.openmrs.module.providermanagement.api.ProviderManagementService;
+import org.openmrs.test.BaseModuleContextSensitiveTest;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+@Ignore
+public class HtmlFormEntryUtilComponentTest extends BaseModuleContextSensitiveTest {
+
+    // TODO: figure out why these tests are failing on bamboo and re-enable!
+
+    @Before
+    public void setup() throws Exception {
+        executeDataSet("org/openmrs/module/htmlformentry/include/providerRoles-dataset.xml");
+    }
+
+    @Test
+    @Ignore
+    public void getProviderRole_shouldGetProviderRoleById() {
+        Object providerRole = HtmlFormEntryUtil.getProviderRole("1002");
+        assertThat(((ProviderRole) providerRole).getName(), is("Binome supervisor"));
+    }
+
+    @Test
+    @Ignore
+    public void getProviderRole_shouldGetProviderRoleByUuid() {
+        Object providerRole = HtmlFormEntryUtil.getProviderRole("ea7f523f-27ce-4bb2-86d6-6d1d05312bd5");
+        assertThat(((ProviderRole) providerRole).getName(), is("Binome supervisor"));
+    }
+
+    @Test
+    @Ignore
+    public void getProviderRole_shouldReturnNullIfBogusId() {
+        Object providerRole = HtmlFormEntryUtil.getProviderRole("some bogus text");
+        assertNull(providerRole);
+    }
+
+    @Test
+    @Ignore
+    public void getProviderRole_shouldReturnNullIfBlank() {
+        Object providerRole = HtmlFormEntryUtil.getProviderRole("");
+        assertNull(providerRole);
+    }
+
+    @Test
+    @Ignore
+    public void getProviders_shouldReturnProvidersForSingleRole() {
+        ProviderRole providerRole = Context.getService(ProviderManagementService.class).getProviderRole(1002);
+        List<Provider> providers = HtmlFormEntryUtil.getProviders(Collections.singletonList(providerRole));
+        assertThat(providers.size(), is(1));
+        assertThat(providers.get(0).getId(), is(1006));
+    }
+
+    @Test
+    @Ignore
+    public void getProviders_shouldReturnProvidersForMultipleRole() {
+
+        List<ProviderRole> providerRoles = new ArrayList<ProviderRole>();
+        providerRoles.add(Context.getService(ProviderManagementService.class).getProviderRole(1001));
+        providerRoles.add(Context.getService(ProviderManagementService.class).getProviderRole(1002));
+
+        List<Provider> providers = HtmlFormEntryUtil.getProviders(providerRoles);
+        assertThat(providers.size(), is(4));
+
+        List<Integer> resultProviderIds = Arrays.asList(1003,1004,1005, 1006);
+
+        for (Provider provider : providers) {
+            assertTrue(resultProviderIds.contains(provider.getId()));
+        }
+    }
+
+    @Test
+    @Ignore
+    public void getProviders_shouldReturnEmptyListIfNoMatches() {
+        ProviderRole providerRole = Context.getService(ProviderManagementService.class).getProviderRole(1004);
+        List<Provider> providers = HtmlFormEntryUtil.getProviders(Collections.singletonList(providerRole));
+        assertThat(providers.size(), is(0));
+    }
+
+    @Test
+    @Ignore
+    public void getProviders_shouldReturnEmptyListIfPassedNull() {
+        List<Provider> providers = HtmlFormEntryUtil.getProviders(null);
+        assertThat(providers.size(), is(0));
+    }
+
+    @Test
+    @Ignore
+    public void getProviders_shouldReturnEmptyListIfPassedEmptyList() {
+        List<Provider> providers = HtmlFormEntryUtil.getProviders(new ArrayList<ProviderRole>());
+        assertThat(providers.size(), is(0));
+    }
+
+}

--- a/api/src/test/java/org/openmrs/module/htmlformentry/HtmlFormEntryUtilTest.java
+++ b/api/src/test/java/org/openmrs/module/htmlformentry/HtmlFormEntryUtilTest.java
@@ -1,0 +1,155 @@
+package org.openmrs.module.htmlformentry;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.openmrs.PersonName;
+import org.openmrs.Provider;
+import org.openmrs.api.ProviderService;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.htmlformentry.element.ProviderStub;
+import org.openmrs.module.htmlformentry.util.MatchMode;
+import org.openmrs.test.BaseModuleContextSensitiveTest;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class HtmlFormEntryUtilTest extends BaseModuleContextSensitiveTest {
+
+    @Before
+    public void setup() throws Exception {
+       executeDataSet("org/openmrs/module/htmlformentry/include/provider-dataset.xml");
+    }
+
+    @Test
+    public void getFullNameWithFamilyNameFirst_shouldReturnProperSimpleName() {
+        PersonName name = new PersonName();
+        name.setGivenName("Mark");
+        name.setFamilyName("Goodrich");
+        assertThat(HtmlFormEntryUtil.getFullNameWithFamilyNameFirst(name), is("Goodrich, Mark"));
+    }
+
+    @Test
+    public void getFullNameWithFamilyNameFirst_shouldReturnProperFullName() {
+        PersonName name = new PersonName();
+        name.setPrefix("Mr.");
+        name.setGivenName("Mark");
+        name.setMiddleName("Brutus");
+        name.setFamilyNamePrefix("de");
+        name.setFamilyName("Cameroon");
+        name.setFamilyName2("Smith");
+        name.setFamilyNameSuffix("Jr.");
+        name.setDegree("Esq.");
+        assertThat(HtmlFormEntryUtil.getFullNameWithFamilyNameFirst(name), is("de Cameroon Smith Jr., Mr. Mark Brutus Esq."));
+    }
+
+    @Test
+    public void getFullNameWithFamilyNameFirst_shouldNotFailIfProviderDoesNotHaveFamilyName() {
+        PersonName name = new PersonName();
+        name.setGivenName("Mark");
+        assertThat(HtmlFormEntryUtil.getFullNameWithFamilyNameFirst(name), is("Mark"));
+    }
+
+    @Test
+    public void getFullNameWithFamilyNameFirst_shouldNotFailIfProviderHasNoName() {
+        PersonName name = new PersonName();
+        assertThat(HtmlFormEntryUtil.getFullNameWithFamilyNameFirst(name), is(""));
+    }
+    
+	@Test
+	public void getFullNameWithFamilyNameFirst_shouldReturnDeletedIfPersonNameIsNull() {
+		assertThat(HtmlFormEntryUtil.getFullNameWithFamilyNameFirst(null), is("["
+		        + Context.getMessageSourceService().getMessage("htmlformentry.unknownProviderName") + "]"));
+	}
+
+    /**
+     * Tests for person names associated with a person object attached to the provider object.
+     */
+    @Test
+    public  void getProviders_shouldReturnProviderStubsWhosePersonNamesStartWithAGivenString() {
+        ProviderService providerService = Context.getProviderService();
+
+        String search = "sura";
+        List<Provider> providers = providerService.getProviders(search, null, null, null);
+        List<ProviderStub> providerStubs =
+                HtmlFormEntryUtil.getProviderStubs(providers,search, MatchMode.START);
+        Provider provider = providerService.getProvider(13002);    //From provider-dataset.xml
+
+        assertTrue(providerStubs.contains(new ProviderStub(provider)));
+    }
+
+    /**
+     * This tests for names stored directly in provider object as name field.
+     */
+    @Test
+    public void getProviders_shouldReturnProvidersStubsWhoseProviderNameStartWithAGivenString() {
+        ProviderService providerService = Context.getProviderService();
+        String search = "kisa";
+        List<Provider> providers = providerService.getProviders(search,null,null,null);
+        List<ProviderStub> providerStubs = HtmlFormEntryUtil.getProviderStubs(providers,search,MatchMode.START);
+        Provider provider = providerService.getProvider(13010);          //From provider-datasets.xml
+
+        assertTrue(providerStubs.contains(new ProviderStub(provider)));
+    }
+
+    /**
+     * Tests for provider identifier stored in provider object
+     */
+    @Test
+    public void getProviders_shouldReturnProviderStubsWhoseIdentifiersStartWithAGivenString() {
+        ProviderService providerService = Context.getProviderService();
+        String search = "5566-1";
+        List<Provider> providers = providerService.getProviders(search,null,null,null);
+        List<ProviderStub> providerStubs = HtmlFormEntryUtil.getProviderStubs(providers,search,MatchMode.START);
+        Provider provider = providerService.getProvider(13002);
+
+        assertTrue(providerStubs.contains(new ProviderStub(provider)));
+    }
+
+    /**
+     * This tests for names stores as person names stored as names of associated person object.
+     */
+    @Test
+    public void getProviders_shouldReturnProviderStubsWhosePersonNamesEndsWithAString() {
+        ProviderService providerService = Context.getProviderService();
+        String search = "rathne";
+        List<Provider> providers = providerService.getProviders(search, null, null, null);
+        List<ProviderStub> providerStubs =
+                HtmlFormEntryUtil.getProviderStubs(providers,search,MatchMode.END);
+        Provider provider = providerService.getProvider(13002);    //From provider-dataset.xml
+
+        assertTrue(providerStubs.contains(new ProviderStub(provider)));
+    }
+
+
+    /**
+     * Tests for names stored directly in provider object as a name field
+     */
+    @Test
+    public void getProviders_shouldReturnProviderStubsWhoseProviderNamesEndWithAGivenString() {
+        ProviderService providerService = Context.getProviderService();
+        String search = "Sanga";
+        List<Provider> providers = providerService.getProviders(search,null,null,null);
+        List<ProviderStub> providerStubs = HtmlFormEntryUtil.getProviderStubs(providers,search,MatchMode.END);
+        Provider provider = providerService.getProvider(13010);          //From provider-datasets.xml
+
+        assertTrue(providerStubs.contains(new ProviderStub(provider)));
+    }
+
+    /**
+     * Tests for provider identifier stored in provider table
+     */
+    @Test
+    public void getProviders_shouldReturnProviderStubsWhoseIdentifierEndsWithAGivenString() {
+        ProviderService providerService = Context.getProviderService();
+        String search = "05-999";
+        List<Provider> providers = providerService.getProviders(search,null,null,null);
+        List<ProviderStub> providerStubs = HtmlFormEntryUtil.getProviderStubs(providers,search,MatchMode.END);
+        Provider provider = providerService.getProvider(13010);
+
+        assertTrue(providerStubs.contains(new ProviderStub(provider)));
+    }
+
+}

--- a/api/src/test/java/org/openmrs/module/htmlformentry/MetadataSharingExportTest.java
+++ b/api/src/test/java/org/openmrs/module/htmlformentry/MetadataSharingExportTest.java
@@ -1,0 +1,52 @@
+/**
+ * The contents of this file are subject to the OpenMRS Public License
+ * Version 1.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://license.openmrs.org
+ *
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
+ */
+package org.openmrs.module.htmlformentry;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openmrs.OpenmrsObject;
+import org.openmrs.api.context.Context;
+import org.openmrs.test.BaseModuleContextSensitiveTest;
+
+import java.util.Collection;
+
+
+/**
+ * Test finding dependencies when doing a Metadata Sharing export of a form with this module's tags
+ */
+public class MetadataSharingExportTest extends BaseModuleContextSensitiveTest {
+
+	@Before
+	public void setup() throws Exception {
+		executeDataSet("org/openmrs/module/htmlformentry/include/encounterProviderAndRole.xml");
+		new HtmlFormEntryActivator().started();
+	}
+	
+	@Test
+	public void testExportWithEncounterRoleAndProvider() throws Exception {
+		HtmlForm form = new HtmlForm();
+		form.setXmlData(new TestUtil().loadXmlFromFile("org/openmrs/module/htmlformentry/include/metadataSharingExportTest.xml"));
+		
+		HtmlFormExporter exporter = new HtmlFormExporter(form);
+		HtmlForm formClone = exporter.export(true, true, true, true);
+		Collection<OpenmrsObject> dependencies = formClone.getDependencies();
+				
+		Assert.assertTrue(dependencies.contains(Context.getEncounterService().getEncounterRoleByUuid("e5c5cc92-5283-11e1-bb6a-d975bd577a5e")));
+		Assert.assertTrue(dependencies.contains(Context.getEncounterService().getEncounterRoleByUuid("eb75d754-5283-11e1-bb6a-d975bd577a5e")));
+		Assert.assertTrue(dependencies.contains(Context.getProviderService().getProviderByUuid("d2299800-cca9-11e0-9572-0800200c9a66")));
+		Assert.assertTrue(dependencies.contains(Context.getProviderService().getProviderByUuid("c2299800-cca9-11e0-9572-0800200c9a66")));
+	}
+	
+}

--- a/api/src/test/java/org/openmrs/module/htmlformentry/element/ProviderRoleAndElementTest.java
+++ b/api/src/test/java/org/openmrs/module/htmlformentry/element/ProviderRoleAndElementTest.java
@@ -1,0 +1,80 @@
+package org.openmrs.module.htmlformentry.element;
+
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.openmrs.Provider;
+import org.openmrs.module.htmlformentry.BadFormDesignException;
+import org.openmrs.test.BaseModuleContextSensitiveTest;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+@Ignore
+public class ProviderRoleAndElementTest extends BaseModuleContextSensitiveTest {
+
+    // TODO: figure out why these tests are failing on bamboo and re-enable!
+
+    @Before
+    public void setup() throws Exception {
+        executeDataSet("org/openmrs/module/htmlformentry/include/providerRoles-dataset.xml");
+    }
+
+    @Test
+    @Ignore
+    public void getProviderList_shouldReturnAllProvidersIfNoRoleSpecified() throws Exception {
+
+        List<Provider> providerList = new ProviderAndRoleElement().getProviderList(new HashMap<String, String>());
+
+        // there are 4 providers in the provider roles dataset and one in the standard test dataset
+        assertThat(providerList.size(), is(5));
+    }
+
+    @Test
+    @Ignore
+    public void getProviderList_shouldReturnProvidersForASingleProviderRole() throws Exception {
+
+        Map<String, String> params = new HashMap<String,String>();
+        params.put("providerRoles", "ea7f523f-27ce-4bb2-86d6-6d1d05312bd5");
+
+        List<Provider> providerList = new ProviderAndRoleElement().getProviderList(params);
+        assertThat(providerList.size(), is(1));
+        assertThat(providerList.get(0).getId(), is(1006));
+
+    }
+
+    @Test
+    @Ignore
+    public void getProviderList_shouldReturnProvidersForMultipleProviderRole() throws Exception {
+
+        Map<String, String> params = new HashMap<String,String>();
+        params.put("providerRoles","ea7f523f-27ce-4bb2-86d6-6d1d05312bd5 , 1001");
+
+        List<Provider> providerList = new ProviderAndRoleElement().getProviderList(params);
+        assertThat(providerList.size(), is(4));
+
+        List<Integer> resultProviderIds = Arrays.asList(1003, 1004, 1005, 1006);
+
+        for (Provider provider : providerList) {
+            assertTrue(resultProviderIds.contains(provider.getId()));
+        }
+
+    }
+
+    @Test(expected = BadFormDesignException.class)
+    @Ignore
+    public void getProviderList_shouldFailIfInvalidId() throws Exception {
+
+        Map<String, String> params = new HashMap<String,String>();
+        params.put("providerRoles", "ea7f523f-27ce-42bd5");
+
+        List<Provider> providerList = new ProviderAndRoleElement().getProviderList(params);
+    }
+
+}

--- a/api/src/test/resources/org/openmrs/module/htmlformentry/include/encounterProviderAndRole.xml
+++ b/api/src/test/resources/org/openmrs/module/htmlformentry/include/encounterProviderAndRole.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<dataset>
+	<provider provider_id="2" name="Doctor Bob, M.D." identifier="ABC123" creator="1" date_created="2005-01-01 00:00:00.0" retired="false" uuid="d2299800-cca9-11e0-9572-0800200c9a66" />
+	<encounter_role encounter_role_id="2" name="Nurse" creator="1" date_created="2005-01-01 00:00:00.0" retired="false" uuid="e5c5cc92-5283-11e1-bb6a-d975bd577a5e"/>
+	<encounter_role encounter_role_id="3" name="Doctor" creator="1" date_created="2005-01-01 00:00:00.0" retired="false" uuid="eb75d754-5283-11e1-bb6a-d975bd577a5e"/>
+</dataset>

--- a/api/src/test/resources/org/openmrs/module/htmlformentry/include/encounterProviderAndRoleTagWithDefault.xml
+++ b/api/src/test/resources/org/openmrs/module/htmlformentry/include/encounterProviderAndRoleTagWithDefault.xml
@@ -1,0 +1,6 @@
+<htmlform>
+	Date: <encounterDate/>
+	Location: <encounterLocation/>
+	ProviderAndRole: <encounterProviderAndRole encounterRole="3" default="2"/>
+	<submit/>
+</htmlform>

--- a/api/src/test/resources/org/openmrs/module/htmlformentry/include/encounterProviderAndRoleTagWithMultipleAndDefault.xml
+++ b/api/src/test/resources/org/openmrs/module/htmlformentry/include/encounterProviderAndRoleTagWithMultipleAndDefault.xml
@@ -1,0 +1,6 @@
+<htmlform>
+    Date: <encounterDate/>
+    Location: <encounterLocation/>
+    ProviderAndRole: <encounterProviderAndRole encounterRole="3" default="2" count="2"/>
+    <submit/>
+</htmlform>

--- a/api/src/test/resources/org/openmrs/module/htmlformentry/include/encounterProviderAndRoleTagWithProviderRolesAttribute.xml
+++ b/api/src/test/resources/org/openmrs/module/htmlformentry/include/encounterProviderAndRoleTagWithProviderRolesAttribute.xml
@@ -1,0 +1,6 @@
+<htmlform>
+    Date: <encounterDate/>
+    Location: <encounterLocation/>
+    ProviderAndRole: <encounterProviderAndRole providerRoles="da7f523f-27ce-4bb2-86d6-6d1d05312bd5"/>
+    <submit/>
+</htmlform>

--- a/api/src/test/resources/org/openmrs/module/htmlformentry/include/metadataSharingExportTest.xml
+++ b/api/src/test/resources/org/openmrs/module/htmlformentry/include/metadataSharingExportTest.xml
@@ -1,0 +1,7 @@
+<htmlform>
+	Date: <encounterDate/>
+	Location: <encounterLocation/>
+	Doctor: <encounterProviderAndRole encounterRole="3" default="d2299800-cca9-11e0-9572-0800200c9a66"/>
+	Nurse: <encounterProviderAndRole encounterRole="e5c5cc92-5283-11e1-bb6a-d975bd577a5e" default="1"/>
+	<submit/>
+</htmlform>

--- a/api/src/test/resources/org/openmrs/module/htmlformentry/include/plainEncounterProviderAndRoleTag.xml
+++ b/api/src/test/resources/org/openmrs/module/htmlformentry/include/plainEncounterProviderAndRoleTag.xml
@@ -1,0 +1,6 @@
+<htmlform>
+	Date: <encounterDate/>
+	Location: <encounterLocation/>
+	ProviderAndRole: <encounterProviderAndRole/>
+	<submit/>
+</htmlform>

--- a/api/src/test/resources/org/openmrs/module/htmlformentry/include/provider-dataset.xml
+++ b/api/src/test/resources/org/openmrs/module/htmlformentry/include/provider-dataset.xml
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<dataset>
+    <person person_id="13000" gender="M" voided="0" creator="1" date_created="2015-06-07" dead="false"
+            uuid="de8140e0-1691-11df-97a5-7038c432aabf" />
+    <person_name person_name_id="13001" person_id="13000" given_name="suranga" family_name="kasthurirathne" voided="false"
+            preferred="true" creator="1" date_created="2015-06-07" uuid="de814b7c-1691-11df-97a5-7038c432aabf"/>
+
+    <provider provider_id="13002" person_id="13000" identifier="5566-111" retired="false" creator="1"
+              date_created="2015-06-07"/>
+    <provider provider_id="13010" name="Thomas Kisanga Kilemule" identifier="34005-999" retired="false"  creator="1"
+              date_created="2015-06-07"/>
+</dataset>

--- a/api/src/test/resources/org/openmrs/module/htmlformentry/include/providerRoles-dataset.xml
+++ b/api/src/test/resources/org/openmrs/module/htmlformentry/include/providerRoles-dataset.xml
@@ -1,0 +1,15 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<dataset>
+
+    <!-- set up the provider roles and relationships and supervisees they support -->
+    <providermanagement_provider_role provider_role_id="1001" name="Binome" creator="1" date_created="2005-09-22 00:00:00.0" retired="false" uuid="da7f523f-27ce-4bb2-86d6-6d1d05312bd5"/>
+    <providermanagement_provider_role provider_role_id="1002" name="Binome supervisor" creator="1" date_created="2005-09-22 00:00:00.0" retired="false" uuid="ea7f523f-27ce-4bb2-86d6-6d1d05312bd5"/>
+    <providermanagement_provider_role provider_role_id="1004" name="Health center supervisor" creator="1" date_created="2005-09-22 00:00:00.0" retired="false" uuid="da8f523f-27ce-4bb2-86d6-6d1e05312bd5"/>
+
+    <provider provider_id="1003" provider_role_id="1001" person_id="2" identifier="2a5" creator="1" date_created="2005-01-01 00:00:00.0" retired="false" uuid="da7f533f-cca9-11e0-9572-0800200c9a66" />
+    <provider provider_id="1004" provider_role_id="1001" person_id="6" identifier="2a6" creator="1" date_created="2005-01-01 00:00:00.0" retired="false" uuid="da7f573f-cca9-11e0-9572-0800200c9a66" />
+    <provider provider_id="1005" provider_role_id="1001" person_id="7" identifier="2a7" creator="1" date_created="2005-01-01 00:00:00.0" retired="false" uuid="da7f513f-cca9-11e0-9572-0800200c9a66" />
+    <provider provider_id="1006" provider_role_id="1002" person_id="8" identifier="2a8" creator="1" date_created="2005-01-01 00:00:00.0" retired="false" uuid="da7d523f-cca9-11e0-9572-0800200c9a66" />
+
+
+</dataset>

--- a/api/src/test/resources/org/openmrs/module/htmlformentry/include/requiredEncounterProviderAndRoleTag.xml
+++ b/api/src/test/resources/org/openmrs/module/htmlformentry/include/requiredEncounterProviderAndRoleTag.xml
@@ -1,0 +1,6 @@
+<htmlform>
+    Date: <encounterDate/>
+    Location: <encounterLocation/>
+    ProviderAndRole: <encounterProviderAndRole required="true"/>
+    <submit/>
+</htmlform>

--- a/api/src/test/resources/org/openmrs/module/htmlformentry/include/specifyingEncounterRoleTwiceWithDifferentRoles.xml
+++ b/api/src/test/resources/org/openmrs/module/htmlformentry/include/specifyingEncounterRoleTwiceWithDifferentRoles.xml
@@ -1,0 +1,7 @@
+<htmlform>
+	Date: <encounterDate/>
+	Location: <encounterLocation/>
+	Doctor: <encounterProviderAndRole encounterRole="3"/>
+	Nurse: <encounterProviderAndRole encounterRole="2"/>
+	<submit/>
+</htmlform>

--- a/api/src/test/resources/org/openmrs/module/htmlformentry/include/specifyingEncounterRoleTwiceWithSameRole.xml
+++ b/api/src/test/resources/org/openmrs/module/htmlformentry/include/specifyingEncounterRoleTwiceWithSameRole.xml
@@ -1,0 +1,6 @@
+<htmlform>
+    Date: <encounterDate/>
+    Location: <encounterLocation/>
+    Doctors: <encounterProviderAndRole encounterRole="3" count="2"/>
+    <submit/>
+</htmlform>

--- a/omod/src/main/java/org/openmrs/module/htmlformentry/web/controller/ProviderSearchController.java
+++ b/omod/src/main/java/org/openmrs/module/htmlformentry/web/controller/ProviderSearchController.java
@@ -1,0 +1,41 @@
+package org.openmrs.module.htmlformentry.web.controller;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.openmrs.Provider;
+import org.openmrs.api.ProviderService;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.htmlformentry.HtmlFormEntryUtil;
+import org.openmrs.module.htmlformentry.element.ProviderStub;
+import org.openmrs.module.htmlformentry.util.MatchMode;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import java.util.List;
+
+@Controller
+public class ProviderSearchController {
+
+    @RequestMapping("/module/htmlformentry19/providers")
+    @ResponseBody
+    public Object getProviders(@RequestParam(value="searchParam",required = false) String searchParam,
+                               @RequestParam(value="matchMode",required=false)MatchMode matchMode)
+            throws Exception {
+        ProviderService ps = Context.getProviderService();
+
+        List<Provider> providerList = null;
+        List<ProviderStub> ret = null;
+        if(searchParam == null) {
+            providerList = ps.getAllProviders();
+            ret = HtmlFormEntryUtil.getProviderStubs(providerList);
+        }
+        else {
+            providerList = ps.getProviders(searchParam, null, null, null);
+            ret = HtmlFormEntryUtil.getProviderStubs(providerList,searchParam,matchMode);
+        }
+
+        return ret;
+    }
+}

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -21,6 +21,7 @@
 	<aware_of_modules>
 	    <aware_of_module>org.openmrs.module.legacyui</aware_of_module>
 		<aware_of_module>org.openmrs.module.metadatamapping</aware_of_module>
+		<aware_of_module>org.openmrs.module.providermanagement</aware_of_module>
 	</aware_of_modules>
 
 	<!-- Extensions -->

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,12 @@
 				<version>0.5</version>
 				<scope>test</scope>
 			</dependency>
+			<dependency>
+				<groupId>org.openmrs.module</groupId>
+				<artifactId>providermanagement-api</artifactId>
+				<version>2.0</version>
+				<scope>provided</scope>
+			</dependency>
             <dependency>
                 <groupId>org.codehaus.jackson</groupId>
                 <artifactId>jackson-mapper-asl</artifactId>


### PR DESCRIPTION
https://issues.openmrs.org/browse/HTML-646

I've executed all steps concerning this module described in issue, beside this one:

> Incorporate the messages.propertes into the HFE messages.properties (be sure to properly push the translations into Transifex); remove the HFE 19ext Transifex project (if one exists)

Messages are moved, I've joined OpenMRS on Transifex, but I think I don't have permissions to push translations or delete projects.