### PR TITLE
HTML-696 - Improve performance of loading forms that utilize concept …

### DIFF
--- a/api-tests/src/test/java/org/openmrs/module/htmlformentry/HtmlFormEntryServiceTest.java
+++ b/api-tests/src/test/java/org/openmrs/module/htmlformentry/HtmlFormEntryServiceTest.java
@@ -1,12 +1,9 @@
 package org.openmrs.module.htmlformentry;
 
-
-import java.io.File;
-import java.util.Date;
-
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.openmrs.Concept;
 import org.openmrs.Patient;
 import org.openmrs.Role;
 import org.openmrs.User;
@@ -16,20 +13,22 @@ import org.openmrs.module.htmlformentry.element.PersonStub;
 import org.openmrs.test.BaseModuleContextSensitiveTest;
 import org.openmrs.test.Verifies;
 import org.openmrs.util.OpenmrsClassLoader;
-import org.openmrs.util.OpenmrsUtil;
+
+import java.util.Date;
 
 public class HtmlFormEntryServiceTest extends BaseModuleContextSensitiveTest {
 
 	protected static final String XML_DATASET_PATH = "org/openmrs/module/htmlformentry/include/";
 	
 	protected static final String XML_HTML_FORM_ENTRY_SERVICE_DATASET = "htmlFormEntryServiceDataSet";
-	
+
 	private HtmlFormEntryService service;
 	
 	@Before
 	public void before() throws Exception {
 		executeDataSet(XML_DATASET_PATH + new TestUtil().getTestDatasetFilename(XML_HTML_FORM_ENTRY_SERVICE_DATASET));
 		service = Context.getService(HtmlFormEntryService.class);
+        service.clearConceptMappingCache();
 	}
 	
 	/**
@@ -42,7 +41,7 @@ public class HtmlFormEntryServiceTest extends BaseModuleContextSensitiveTest {
 	}
 	
 	/**
-	 * @see {@link HtmlFormEntryService#getHtmlFormByUuid()}
+	 * @see {@link HtmlFormEntryService#getHtmlFormByUuid(String)}
 	 */
 	@Test
 	@Verifies(value = "should return the HtmlForm with the given uuid", method = "getHtmlFormByUuid()")
@@ -51,7 +50,7 @@ public class HtmlFormEntryServiceTest extends BaseModuleContextSensitiveTest {
 	}
 	
 	/**
-     * @see {@link HtmlFormEntryService#getProviderStub()}
+     * @see {@link HtmlFormEntryService#getUsersAsPersonStubs(String)}
      */
     @Test
     @Verifies(value = "should return all ProviderStubs", method = "getProviderStub()")
@@ -108,5 +107,18 @@ public class HtmlFormEntryServiceTest extends BaseModuleContextSensitiveTest {
 
         Assert.assertEquals(noEnc+1,newNoEnc);
     }
-	
+
+	@Test
+	public void getConceptByMapping_shouldRetrieveConceptByMapping() throws Exception {
+    	Concept concept = service.getConceptByMapping("XYZ:HT");
+    	Assert.assertEquals(3, concept.getConceptId().intValue());
+	}
+
+	@Test
+	public void getConceptByMapping_shouldReturnNullIfInvalidMappingSpecified() throws Exception {
+		Concept concept = service.getConceptByMapping("XYZ-HT");
+		Assert.assertNull(concept);
+		concept = service.getConceptByMapping("XYZ123:HT");
+		Assert.assertNull(concept);
+	}
 }

--- a/api/src/main/java/org/openmrs/module/htmlformentry/HtmlFormEntryService.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/HtmlFormEntryService.java
@@ -3,6 +3,7 @@ package org.openmrs.module.htmlformentry;
 import java.util.List;
 import java.util.Map;
 
+import org.openmrs.Concept;
 import org.openmrs.Form;
 import org.openmrs.OpenmrsMetadata;
 import org.openmrs.OpenmrsObject;
@@ -184,4 +185,19 @@ public interface HtmlFormEntryService extends OpenmrsService {
     public void reprocessArchivedForm(String argument,boolean isPath) throws Exception;
 
     public void reprocessArchivedForm(String path) throws Exception;
+
+	/**
+	 * This returns a single Concept represented by the mapping String sourceNameOrHl7Code:referenceTerm
+	 * If multiple Concepts match the given mapping, then:
+	 *  - if only one of these is non-retired, return that concept
+	 *  - otherwise, throw an ApiException
+	 */
+	@Transactional(readOnly=true)
+	public Concept getConceptByMapping(String sourceNameOrHl7CodeAndTerm);
+
+	/**
+	 * Clears the concept mapping cache if needed to ensure no stale mappings exist
+	 */
+	@Transactional(readOnly=true)
+	public void clearConceptMappingCache();
 }

--- a/api/src/main/java/org/openmrs/module/htmlformentry/HtmlFormEntryUtil.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/HtmlFormEntryUtil.java
@@ -571,10 +571,7 @@ public class HtmlFormEntryUtil {
 			// handle  mapping id: xyz:ht
 			int index = id.indexOf(":");
 			if (index != -1) {
-				String mappingCode = id.substring(0, index).trim();
-				String conceptCode = id.substring(index + 1, id.length()).trim();
-				cpt = Context.getConceptService().getConceptByMapping(conceptCode, mappingCode);
-
+				cpt = Context.getService(HtmlFormEntryService.class).getConceptByMapping(id);
 				if (cpt != null) {
 					return cpt;
 				}

--- a/api/src/test/resources/org/openmrs/module/htmlformentry/include/HtmlFormEntryService-data-openmrs-1.10.xml
+++ b/api/src/test/resources/org/openmrs/module/htmlformentry/include/HtmlFormEntryService-data-openmrs-1.10.xml
@@ -13,7 +13,11 @@
   <concept_name voided="false" concept_name_id="3" concept_id="2" name="POIDS (KG)" locale="fr" creator="1" date_created="2005-01-01 00:00:00.0"  locale_preferred="true"/>
   <concept concept_id="3" creator="1" date_created="2005-01-01 00:00:00.0" retired="false" is_set="false" datatype_id="1"/>
   <concept_name voided="false" concept_name_id="4" concept_id="3" name="HEIGHT (CM)" locale="en" creator="1" date_created="2005-01-01 00:00:00.0"  locale_preferred="true"/>
-  
+
+  <concept_reference_source concept_source_id="1" uuid="931abfea-b2ca-49e7-b7ff-7420055f0ea1" name="XYZ" hl7_code="XYZHL7" date_Created="2010-07-09 11:00:38" retired="false" creator="1" />
+  <concept_reference_map concept_map_id="1" concept_map_type_id="1" concept_reference_term_id="15" uuid="26755d29-9cc3-43bc-bc86-1c1df20f698f" concept_id="3" creator="1"  date_created="2010-07-09 11:00:38"/>
+  <concept_reference_term concept_reference_term_id="15" concept_source_id="1" code="HT" name="height term" description="A person's height in kilograms" retired="0" creator="1" date_created="2004-08-12 00:00:00.0" uuid="26755d29-9cc3-43bc-bc86-1c1df20f6987" />
+
   <!-- Required metadata -->
   <location location_id="1" name="Test Location" creator="1" date_created="2005-01-01 00:00:00.0" retired="false" />
   <encounter_type encounter_type_id="1" name="Initial Visit" description="The first visit for a patient" creator="1" date_created="2005-01-01 00:00:00.0" retired="false" />

--- a/api/src/test/resources/org/openmrs/module/htmlformentry/include/HtmlFormEntryService-data-openmrs-1.6.xml
+++ b/api/src/test/resources/org/openmrs/module/htmlformentry/include/HtmlFormEntryService-data-openmrs-1.6.xml
@@ -13,7 +13,10 @@
   <concept_name voided="false" concept_name_id="3" concept_id="2" name="POIDS (KG)" locale="fr" creator="1" date_created="2005-01-01 00:00:00.0" />
   <concept concept_id="3" creator="1" date_created="2005-01-01 00:00:00.0" retired="false" is_set="false" datatype_id="1"/>
   <concept_name voided="false" concept_name_id="4" concept_id="3" name="HEIGHT (CM)" locale="en" creator="1" date_created="2005-01-01 00:00:00.0" />
-  
+
+  <concept_source concept_source_id="1" uuid="931abfea-b2ca-49e7-b7ff-7420055f0ea1" name="XYZ" date_Created="2010-07-09 11:00:38" retired="false" creator="1" />
+  <concept_map concept_map_id="1" uuid="26755d29-9cc3-43bc-bc86-1c1df20f698f" concept_id="3" source="1" source_code="HT" creator="1"  date_created="2010-07-09 11:00:38"/>
+
   <!-- Required metadata -->
   <location location_id="1" name="Test Location" creator="1" date_created="2005-01-01 00:00:00.0" retired="false" />
   <encounter_type encounter_type_id="1" name="Initial Visit" description="The first visit for a patient" creator="1" date_created="2005-01-01 00:00:00.0" retired="false" />

--- a/api/src/test/resources/org/openmrs/module/htmlformentry/include/HtmlFormEntryService-data-openmrs-1.7.xml
+++ b/api/src/test/resources/org/openmrs/module/htmlformentry/include/HtmlFormEntryService-data-openmrs-1.7.xml
@@ -13,7 +13,10 @@
   <concept_name voided="false" concept_name_id="3" concept_id="2" name="POIDS (KG)" locale="fr" creator="1" date_created="2005-01-01 00:00:00.0"  locale_preferred="true"/>
   <concept concept_id="3" creator="1" date_created="2005-01-01 00:00:00.0" retired="false" is_set="false" datatype_id="1"/>
   <concept_name voided="false" concept_name_id="4" concept_id="3" name="HEIGHT (CM)" locale="en" creator="1" date_created="2005-01-01 00:00:00.0"  locale_preferred="true"/>
-  
+
+  <concept_source concept_source_id="1" uuid="931abfea-b2ca-49e7-b7ff-7420055f0ea1" name="XYZ" date_Created="2010-07-09 11:00:38" retired="false" creator="1" />
+  <concept_map concept_map_id="1" uuid="26755d29-9cc3-43bc-bc86-1c1df20f698f" concept_id="3" source="1" source_code="HT" creator="1"  date_created="2010-07-09 11:00:38"/>
+
   <!-- Required metadata -->
   <location location_id="1" name="Test Location" creator="1" date_created="2005-01-01 00:00:00.0" retired="false" />
   <encounter_type encounter_type_id="1" name="Initial Visit" description="The first visit for a patient" creator="1" date_created="2005-01-01 00:00:00.0" retired="false" />

--- a/api/src/test/resources/org/openmrs/module/htmlformentry/include/HtmlFormEntryService-data-openmrs-1.8.xml
+++ b/api/src/test/resources/org/openmrs/module/htmlformentry/include/HtmlFormEntryService-data-openmrs-1.8.xml
@@ -13,7 +13,14 @@
   <concept_name voided="false" concept_name_id="3" concept_id="2" name="POIDS (KG)" locale="fr" creator="1" date_created="2005-01-01 00:00:00.0"  locale_preferred="true"/>
   <concept concept_id="3" creator="1" date_created="2005-01-01 00:00:00.0" retired="false" is_set="false" datatype_id="1"/>
   <concept_name voided="false" concept_name_id="4" concept_id="3" name="HEIGHT (CM)" locale="en" creator="1" date_created="2005-01-01 00:00:00.0"  locale_preferred="true"/>
-  
+
+  <concept_reference_source concept_source_id="1" uuid="931abfea-b2ca-49e7-b7ff-7420055f0ea1" name="XYZ" hl7_code="XYZHL7" date_Created="2010-07-09 11:00:38" retired="false" creator="1" />
+  <concept_reference_map concept_map_id="1" concept_map_type_id="1" concept_reference_term_id="15" uuid="26755d29-9cc3-43bc-bc86-1c1df20f698f" concept_id="3" creator="1"  date_created="2010-07-09 11:00:38"/>
+  <concept_reference_term concept_reference_term_id="15" concept_source_id="1" code="HT" name="height term" description="A person's height in kilograms" retired="0" creator="1" date_created="2004-08-12 00:00:00.0" uuid="26755d29-9cc3-43bc-bc86-1c1df20f6987" />
+
+  <concept_source concept_source_id="1" uuid="931abfea-b2ca-49e7-b7ff-7420055f0ea1" name="XYZ" date_Created="2010-07-09 11:00:38" retired="false" creator="1" />
+  <concept_map concept_map_id="1" uuid="26755d29-9cc3-43bc-bc86-1c1df20f698f" concept_id="3" source="1" source_code="HT" creator="1"  date_created="2010-07-09 11:00:38"/>
+
   <!-- Required metadata -->
   <location location_id="1" name="Test Location" creator="1" date_created="2005-01-01 00:00:00.0" retired="false" />
   <encounter_type encounter_type_id="1" name="Initial Visit" description="The first visit for a patient" creator="1" date_created="2005-01-01 00:00:00.0" retired="false" />

--- a/api/src/test/resources/org/openmrs/module/htmlformentry/include/HtmlFormEntryService-data-openmrs-1.9.xml
+++ b/api/src/test/resources/org/openmrs/module/htmlformentry/include/HtmlFormEntryService-data-openmrs-1.9.xml
@@ -13,11 +13,15 @@
   <concept_name voided="false" concept_name_id="3" concept_id="2" name="POIDS (KG)" locale="fr" creator="1" date_created="2005-01-01 00:00:00.0"  locale_preferred="true"/>
   <concept concept_id="3" creator="1" date_created="2005-01-01 00:00:00.0" retired="false" is_set="false" datatype_id="1"/>
   <concept_name voided="false" concept_name_id="4" concept_id="3" name="HEIGHT (CM)" locale="en" creator="1" date_created="2005-01-01 00:00:00.0"  locale_preferred="true"/>
-  
+
+  <concept_reference_source concept_source_id="1" uuid="931abfea-b2ca-49e7-b7ff-7420055f0ea1" name="XYZ" hl7_code="XYZHL7" date_Created="2010-07-09 11:00:38" retired="false" creator="1" />
+  <concept_reference_map concept_map_id="1" concept_map_type_id="1" concept_reference_term_id="15" uuid="26755d29-9cc3-43bc-bc86-1c1df20f698f" concept_id="3" creator="1"  date_created="2010-07-09 11:00:38"/>
+  <concept_reference_term concept_reference_term_id="15" concept_source_id="1" code="HT" name="height term" description="A person's height in kilograms" retired="0" creator="1" date_created="2004-08-12 00:00:00.0" uuid="26755d29-9cc3-43bc-bc86-1c1df20f6987" />
+
   <!-- Required metadata -->
   <location location_id="1" name="Test Location" creator="1" date_created="2005-01-01 00:00:00.0" retired="false" />
   <encounter_type encounter_type_id="1" name="Initial Visit" description="The first visit for a patient" creator="1" date_created="2005-01-01 00:00:00.0" retired="false" />
-  
+
   <!-- Two forms -->
   <form form_id="1" name="Test form" version="1.0" build="1" published="true" description="A form for testing" encounter_type="1" creator="1" date_created="2005-01-01 00:00:00.0" retired="false"/>
   <form form_id="2" name="Form two" version="1.0" build="1" published="true" description="A form for testing" encounter_type="1" creator="1" date_created="2005-01-01 00:00:00.0" retired="false"/>


### PR DESCRIPTION
…mapping codes

## Description of what I changed
This introduces a simple Map<String, Integer> cache on htmlformentryservice that maintains a cache of a mapping code in "source:code" format -> conceptId.  This enables much faster performance when loading an htmlform that contains the same concept mapping lookups multiple times (eg. in a repeat tag, or with common answers).  It also enables faster performance when loading forms subsequent to the first time a form is loaded after a context refresh.  An additional service method has been added to clear the cache, so distribution modules can choose to do this if needed upon activation if they load concepts via liquibase or SQL.
