### PR TITLE
HTML-755: Conversion from client to server timezone.

### DIFF
--- a/api-tests/src/test/java/org/openmrs/module/htmlformentry/EncounterDateTagTest.java
+++ b/api-tests/src/test/java/org/openmrs/module/htmlformentry/EncounterDateTagTest.java
@@ -1,0 +1,59 @@
+package org.openmrs.module.htmlformentry;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Map;
+import java.util.TimeZone;
+
+import static java.util.Calendar.MILLISECOND;
+
+public class EncounterDateTagTest extends BaseHtmlFormEntryTest {
+	
+	@Test
+	public void testSubmitEncounterDatetimeWithTimeZone() throws Exception {
+		new RegressionTestHelper() {
+			
+			@Override
+			public String getFormName() {
+				return "";
+			}
+			
+			@Override
+			public String getFormXml() {
+				return "<htmlform> Datetime: <encounterDate showTime=\"true\" /> </htmlform>";
+			}
+			
+			@Override
+			public String[] widgetLabels() {
+				return new String[] { "Datetime" };
+			}
+			
+			@Override
+			public void setupRequest(MockHttpServletRequest request, Map<String, String> widgets) {
+				request.setParameter(widgets.get("Datetime"), "2020-11-16");
+				request.setParameter("w1hours", "7");
+				request.setParameter("w1minutes", "25");
+				request.setParameter("w1seconds", "58");
+				request.setParameter("w1timeZone", "Pacific/Kiritimati");
+			}
+			
+			@Override
+			public void testResults(SubmissionResults results) {
+				Calendar cal = Calendar.getInstance();
+				cal.set(2020, 11 - 1, 16, 7, 25, 58);
+				cal.set(MILLISECOND, 0);
+				cal.setTimeZone(TimeZone.getTimeZone("Pacific/Kiritimati"));
+				Date expectedDateTime = cal.getTime();
+				
+				Date encounterDateTime = results.getEncounterCreated().getEncounterDatetime();
+				
+				Assert.assertEquals(expectedDateTime, encounterDateTime);
+			}
+			
+		}.run();
+	}
+}

--- a/api/src/main/java/org/openmrs/module/htmlformentry/HtmlFormEntryUtil.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/HtmlFormEntryUtil.java
@@ -20,23 +20,7 @@ import java.lang.reflect.Method;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.GregorianCalendar;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
-import java.util.UUID;
+import java.util.*;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.BooleanUtils;
@@ -532,7 +516,7 @@ public class HtmlFormEntryUtil {
 	 * @param time the Date object that contains time information
 	 * @return a Date object with the combined date/time
 	 */
-	public static Date combineDateAndTime(Date date, Date time) {
+	public static Date combineDateAndTime(Date date, Date time, String timeZone) {
 		if (date == null)
 			return null;
 		Calendar cal = Calendar.getInstance();
@@ -545,6 +529,10 @@ public class HtmlFormEntryUtil {
 			cal.set(Calendar.MINUTE, temp.get(Calendar.MINUTE));
 			cal.set(Calendar.SECOND, temp.get(Calendar.SECOND));
 			cal.set(Calendar.MILLISECOND, temp.get(Calendar.MILLISECOND));
+			if (StringUtils.isNotEmpty(timeZone)) {
+				TimeZone tz = TimeZone.getTimeZone(timeZone);
+				cal.setTimeZone(tz);
+			}
 		}
 		return cal.getTime();
 	}

--- a/api/src/main/java/org/openmrs/module/htmlformentry/element/EncounterDetailSubmissionElement.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/element/EncounterDetailSubmissionElement.java
@@ -771,7 +771,8 @@ public class EncounterDetailSubmissionElement implements HtmlGeneratorElement, F
 				Date date = (Date) dateWidget.getValue(context, submission);
 				if (timeWidget != null) {
 					Date time = (Date) timeWidget.getValue(context, submission);
-					date = HtmlFormEntryUtil.combineDateAndTime(date, time);
+					String timeZone = timeWidget.getTimeZone(context, submission);
+					date = HtmlFormEntryUtil.combineDateAndTime(date, time, timeZone);
 				}
 				if (date == null)
 					throw new Exception("htmlformentry.error.required");
@@ -885,7 +886,8 @@ public class EncounterDetailSubmissionElement implements HtmlGeneratorElement, F
 		if (timeWidget != null) {
 			Date time = (Date) timeWidget.getValue(session.getContext(), submission);
 			Encounter e = session.getSubmissionActions().getCurrentEncounter();
-			Date dateAndTime = HtmlFormEntryUtil.combineDateAndTime(e.getEncounterDatetime(), time);
+			String timeZone = timeWidget.getTimeZone(session.getContext(), submission);
+			Date dateAndTime = HtmlFormEntryUtil.combineDateAndTime(e.getEncounterDatetime(), time, timeZone);
 			e.setEncounterDatetime(dateAndTime);
 		}
 		if (providerWidget != null) {

--- a/api/src/main/java/org/openmrs/module/htmlformentry/widget/DateTimeWidget.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/widget/DateTimeWidget.java
@@ -57,9 +57,10 @@ public class DateTimeWidget implements Widget {
 		
 		// get the values from the associated date and time widgets
 		Date date = dateWidget.getValue(context, request);
+		String timeZone = timeWidget.getTimeZone(context, request);
 		Date time = (Date) timeWidget.getValue(context, request);
 		
-		return HtmlFormEntryUtil.combineDateAndTime(date, time);
+		return HtmlFormEntryUtil.combineDateAndTime(date, time, timeZone);
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/module/htmlformentry/widget/TimeWidget.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/widget/TimeWidget.java
@@ -49,8 +49,15 @@ public class TimeWidget implements Widget {
 		if (context.getMode() == Mode.VIEW) {
 			String toPrint = "";
 			if (initialValue != null) {
+				StringBuilder sb = new StringBuilder();
 				toPrint = timeFormat().format(initialValue);
-				return WidgetFactory.displayValue(toPrint);
+				sb.append(WidgetFactory.displayValue(toPrint));
+				//Format the datetime with server timezone
+				String format = "yyyy-MM-dd'T'HH:mm:ssZ";
+				SimpleDateFormat dateFormatter = new SimpleDateFormat(format);
+				sb.append("<span class=\"hfe-dateTime\" value=\"").append(dateFormatter.format(initialValue))
+						.append("\">");
+				return sb.toString();
 			} else {
 				if (hideSeconds) {
 					toPrint = "___:___";
@@ -124,6 +131,9 @@ public class TimeWidget implements Widget {
 					}
 					sb.append("</select>");
 				}
+				sb.append("<input type=\"hidden\" class=\"hfe-timeZone\" name=\"").append(context.getFieldName(this))
+						.append("timeZone").append("\">");
+				sb.append("</input>");
 			}
 			
 			return sb.toString();
@@ -134,6 +144,18 @@ public class TimeWidget implements Widget {
 	 * @see org.openmrs.module.htmlformentry.widget.Widget#getValue(org.openmrs.module.htmlformentry.FormEntryContext,
 	 *      javax.servlet.http.HttpServletRequest)
 	 */
+
+	public String getTimeZone(FormEntryContext context, HttpServletRequest request) {
+		try {
+			String tz = (String) HtmlFormEntryUtil.getParameterAsType(request, context.getFieldName(this) + "timeZone",
+					String.class);
+			return tz;
+		}
+		catch (Exception ex) {
+			throw new IllegalArgumentException("Illegal value");
+		}
+	}
+
 	@Override
 	public Object getValue(FormEntryContext context, HttpServletRequest request) {
 		try {

--- a/api/src/main/java/org/openmrs/module/htmlformentry/widget/TimeWidget.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/widget/TimeWidget.java
@@ -51,12 +51,11 @@ public class TimeWidget implements Widget {
 			if (initialValue != null) {
 				StringBuilder sb = new StringBuilder();
 				toPrint = timeFormat().format(initialValue);
-				sb.append(WidgetFactory.displayValue(toPrint));
-				//Format the datetime with server timezone
-				String format = "yyyy-MM-dd'T'HH:mm:ssZ";
-				SimpleDateFormat dateFormatter = new SimpleDateFormat(format);
-				sb.append("<span class=\"hfe-dateTime\" value=\"").append(dateFormatter.format(initialValue))
-						.append("\">");
+				//Get server timezone
+				SimpleDateFormat dateFormatYouWant = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
+				String newDate = dateFormatYouWant.format(initialValue);
+				String timezone = newDate.substring(newDate.length()-5);
+				sb.append("<span class=\"value\" tz=\"").append(timezone).append("\">").append(toPrint).append("</span>");
 				return sb.toString();
 			} else {
 				if (hideSeconds) {

--- a/api/src/test/java/org/openmrs/module/htmlformentry/widget/TimeWidgetTest.java
+++ b/api/src/test/java/org/openmrs/module/htmlformentry/widget/TimeWidgetTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
+import org.apache.commons.lang.StringUtils;
 import org.junit.Test;
 import org.openmrs.GlobalProperty;
 import org.openmrs.api.context.Context;
@@ -60,7 +61,7 @@ public class TimeWidgetTest extends BaseHtmlFormEntryTest {
 		when(formEntryContext.getMode()).thenReturn(FormEntryContext.Mode.VIEW);
 		String html = widget.generateHtml(formEntryContext);
 		String expected = "<span class=\"value\">" + expectedValue + "</span>";
-		assertEquals(expected, html);
+		assertTrue(StringUtils.containsIgnoreCase(html, expected));
 	}
 	
 	protected void setGlobalProperty(String format) {


### PR DESCRIPTION
[DRAFT] HTML-755 Convert from client timezone to server timezone before saving on DB.
This only works if the`<encounterDate>`  tag have ` showTime=true `