### PR TITLE
Add null guard for more useful error message

### DIFF
--- a/api/src/main/java/org/openmrs/module/htmlformentry/ObsGroupComponent.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/ObsGroupComponent.java
@@ -113,8 +113,14 @@ public class ObsGroupComponent {
 			Set<Integer> obsGroupComponentMatchLog = new HashSet<Integer>();
 			
 			for (ObsGroupComponent obsGroupComponent : obsGroupComponents) {
-				boolean questionMatches = obsGroupComponent.getQuestion().getConceptId()
-				        .equals(obs.getConcept().getConceptId());
+				Concept groupComponentQuestion = obsGroupComponent.getQuestion();
+				if (groupComponentQuestion == null) {
+					// The correct error should be thrown with useful contextual information from ObsSubmissionElement:174
+					// https://github.com/openmrs/openmrs-module-htmlformentry/blob/e6188717db16fc681ac4ec5d1610f251f214c372/api/src/main/java/org/openmrs/module/htmlformentry/element/ObsSubmissionElement.java#L174
+					continue;
+				}
+				
+				boolean questionMatches = groupComponentQuestion.getConceptId().equals(obs.getConcept().getConceptId());
 				boolean answerMatches = false;
 				
 				if (obsGroupComponent.getAnswerDrug() == null) {


### PR DESCRIPTION
Ran into an NPE when there was an obs grouping concept missing. This improves the error from an NPE to

```
Caused by: java.lang.IllegalArgumentException: Cannot find concept for value CIEL:164352 in conceptId attribute value. Parameters: {answerConceptIds=CIEL:1527,PIH:GUARDIAN,PIH:PARTNER OR SPOUSE,CIEL:1528,PIH:SIBLING,PIH:OTHER RELATIVE, conceptId=CIEL:164352, labelCode=pihcore.contactRelationship}
        at org.openmrs.module.htmlformentry.element.ObsSubmissionElement.<init>(ObsSubmissionElement.java:174)
```