### PR TITLE
HTML-759 - Drug order tag updates following initial testing and feedback

### DIFF
--- a/api-tests/src/test/java/org/openmrs/module/htmlformentry/HtmlFormEntryUtilTest.java
+++ b/api-tests/src/test/java/org/openmrs/module/htmlformentry/HtmlFormEntryUtilTest.java
@@ -1265,12 +1265,11 @@ public class HtmlFormEntryUtilTest extends BaseHtmlFormEntryTest {
 		Patient patient = Context.getPatientService().getPatient(2);
 		Drug drug3 = Context.getConceptService().getDrug(3);
 		Drug drug11 = Context.getConceptService().getDrug(11);
-		Set<Drug> drugs = new HashSet<>();
-		drugs.add(drug3);
-		drugs.add(drug11);
-		Map<Drug, List<DrugOrder>> m = HtmlFormEntryUtil.getDrugOrdersForPatient(patient, drugs);
-		Assert.assertEquals(3, m.get(drug3).size());
-		Assert.assertEquals(1, m.get(drug11).size());
+		Set<Concept> concepts = new HashSet<>();
+		concepts.add(drug3.getConcept());
+		concepts.add(drug11.getConcept());
+		List<DrugOrder> m = HtmlFormEntryUtil.getDrugOrdersForPatient(patient, concepts);
+		Assert.assertEquals(4, m.size());
 	}
 	
 	/**

--- a/api-tests/src/test/java/org/openmrs/module/htmlformentry/element/DrugOrderSubmissionElementTest.java
+++ b/api-tests/src/test/java/org/openmrs/module/htmlformentry/element/DrugOrderSubmissionElementTest.java
@@ -296,7 +296,7 @@ public class DrugOrderSubmissionElementTest extends BaseHtmlFormEntryTest {
 		DrugOrder originalOrder = results.assertDrugOrder(Order.Action.NEW, 2);
 		
 		FormSessionTester reviseTester = formSessionTester.reopenForEditing(results);
-		DrugOrderFieldTester revisedTriomuneField = DrugOrderFieldTester.forDrug(2, reviseTester);
+		DrugOrderFieldTester revisedTriomuneField = DrugOrderFieldTester.forDrug(2, triomuneField.getSuffix(), reviseTester);
 		revisedTriomuneField.orderAction("REVISE").previousOrder(originalOrder.getId().toString());
 		revisedTriomuneField.freeTextDosing("Revised Triomune instructions");
 		FormResultsTester revisedResults = reviseTester.submitForm();
@@ -331,7 +331,7 @@ public class DrugOrderSubmissionElementTest extends BaseHtmlFormEntryTest {
 		// Then, we revise this above revision
 		
 		FormSessionTester editSession2 = editSession1.reopenForEditing(results1);
-		DrugOrderFieldTester revision2 = DrugOrderFieldTester.forDrug(2, editSession2);
+		DrugOrderFieldTester revision2 = DrugOrderFieldTester.forDrug(2, revision1.getSuffix(), editSession2);
 		revision2.orderAction("REVISE").previousOrder(order1.getId().toString());
 		revision2.freeTextDosing("My revision revision");
 		FormResultsTester results2 = editSession2.submitForm();

--- a/api-tests/src/test/java/org/openmrs/module/htmlformentry/handler/DrugOrderTagHandlerTest.java
+++ b/api-tests/src/test/java/org/openmrs/module/htmlformentry/handler/DrugOrderTagHandlerTest.java
@@ -133,7 +133,7 @@ public class DrugOrderTagHandlerTest extends BaseHtmlFormEntryTest {
 	public void shouldSupportActionConfigurationProperties() {
 		DrugOrderWidget w = getDrugOrderWidgets("drugOrderTestFormOrderProperties.xml").get(0);
 		assertThat(w.getWidgetConfig().getOrderPropertyOptions("action").size(), is(3));
-		assertOrderPropertyOption(w, "action", 1, "NEW", "New Order"); // Default
+		assertOrderPropertyOption(w, "action", 1, "NEW", "New"); // Default
 		assertOrderPropertyOption(w, "action", 2, "REVISE", "Revise this Order"); // Explicit
 		assertOrderPropertyOption(w, "action", 3, "DISCONTINUE", "HTML Form Entry"); // Translated
 		assertValueAttribute(w, "action", "NEW");

--- a/api-tests/src/test/java/org/openmrs/module/htmlformentry/widget/DrugOrderWidgetTest.java
+++ b/api-tests/src/test/java/org/openmrs/module/htmlformentry/widget/DrugOrderWidgetTest.java
@@ -42,9 +42,10 @@ public class DrugOrderWidgetTest extends BaseHtmlFormEntryTest {
 		FormSessionTester fst = formTester.openNewForm(2);
 		DrugOrderWidget widget = fst.getWidgets(DrugOrderWidget.class).get(0);
 		String[] properties = { "concept", "drug", "drugNonCoded", "action", "previousOrder", "careSetting", "dosingType",
-		        "orderType", "dosingInstructions", "dose", "doseUnits", "route", "frequency", "asNeeded", "instructions",
-		        "urgency", "dateActivated", "scheduledDate", "duration", "durationUnits", "quantity", "quantityUnits",
-		        "numRefills", "voided", "discontinueReason", "discontinueReasonNonCoded" };
+		        "orderType", "orderReason", "orderReasonNonCoded", "dosingInstructions", "dose", "doseUnits", "route",
+		        "frequency", "asNeeded", "instructions", "urgency", "dateActivated", "scheduledDate", "duration",
+		        "durationUnits", "quantity", "quantityUnits", "numRefills", "discontinueReason",
+		        "discontinueReasonNonCoded" };
 		assertThat(widget.getWidgets().size(), is(properties.length));
 		List<Widget> widgets = new ArrayList<>(widget.getWidgets().values());
 		for (int i = 0; i < widgets.size(); i++) {

--- a/api-tests/src/test/java/org/openmrs/module/htmlformentry/widget/DrugOrderWidgetTest.java
+++ b/api-tests/src/test/java/org/openmrs/module/htmlformentry/widget/DrugOrderWidgetTest.java
@@ -32,7 +32,7 @@ public class DrugOrderWidgetTest extends BaseHtmlFormEntryTest {
 		formSessionTester.assertHtmlContains("drugorders-order-section");
 		formSessionTester.assertHtmlContains("drugorders-selector-section");
 		formSessionTester.assertHtmlContains("drugorders-order-form");
-		formSessionTester.assertStartingFormValue("order-field-label orderType", "1");
+		formSessionTester.assertStartingFormValue("order-field-label order-orderType", "1");
 		log.trace(formSessionTester.getHtmlToDisplay());
 	}
 	
@@ -50,9 +50,9 @@ public class DrugOrderWidgetTest extends BaseHtmlFormEntryTest {
 		for (int i = 0; i < widgets.size(); i++) {
 			String property = properties[i];
 			Widget propertyWidget = widgets.get(i);
-			fst.assertHtmlContains("<div class=\"order-field " + property + "\"");
-			fst.assertHtmlContains("<div class=\"order-field-label " + property + "\"");
-			fst.assertHtmlContains("<div class=\"order-field-widget " + property);
+			fst.assertHtmlContains("<div class=\"order-field order-" + property + "\"");
+			fst.assertHtmlContains("<div class=\"order-field-label order-" + property + "\"");
+			fst.assertHtmlContains("<div class=\"order-field-widget order-" + property);
 			fst.assertHtmlContains(propertyWidget.generateHtml(fst.getFormEntrySession().getContext()));
 		}
 	}

--- a/api-tests/src/test/java/org/openmrs/module/htmlformentry/widget/DrugOrderWidgetTest.java
+++ b/api-tests/src/test/java/org/openmrs/module/htmlformentry/widget/DrugOrderWidgetTest.java
@@ -44,7 +44,7 @@ public class DrugOrderWidgetTest extends BaseHtmlFormEntryTest {
 		String[] properties = { "concept", "drug", "drugNonCoded", "action", "previousOrder", "careSetting", "dosingType",
 		        "orderType", "dosingInstructions", "dose", "doseUnits", "route", "frequency", "asNeeded", "instructions",
 		        "urgency", "dateActivated", "scheduledDate", "duration", "durationUnits", "quantity", "quantityUnits",
-		        "numRefills", "voided", "discontinueReason" };
+		        "numRefills", "voided", "discontinueReason", "discontinueReasonNonCoded" };
 		assertThat(widget.getWidgets().size(), is(properties.length));
 		List<Widget> widgets = new ArrayList<>(widget.getWidgets().values());
 		for (int i = 0; i < widgets.size(); i++) {

--- a/api-tests/src/test/java/org/openmrs/module/htmlformentry/widget/DrugOrderWidgetTest.java
+++ b/api-tests/src/test/java/org/openmrs/module/htmlformentry/widget/DrugOrderWidgetTest.java
@@ -41,10 +41,10 @@ public class DrugOrderWidgetTest extends BaseHtmlFormEntryTest {
 		FormTester formTester = FormTester.buildForm("drugOrderTestForm.xml");
 		FormSessionTester fst = formTester.openNewForm(2);
 		DrugOrderWidget widget = fst.getWidgets(DrugOrderWidget.class).get(0);
-		String[] properties = { "drug", "action", "previousOrder", "careSetting", "dosingType", "orderType",
-		        "dosingInstructions", "dose", "doseUnits", "route", "frequency", "asNeeded", "instructions", "urgency",
-		        "dateActivated", "scheduledDate", "duration", "durationUnits", "quantity", "quantityUnits", "numRefills",
-		        "voided", "discontinueReason" };
+		String[] properties = { "concept", "drug", "drugNonCoded", "action", "previousOrder", "careSetting", "dosingType",
+		        "orderType", "dosingInstructions", "dose", "doseUnits", "route", "frequency", "asNeeded", "instructions",
+		        "urgency", "dateActivated", "scheduledDate", "duration", "durationUnits", "quantity", "quantityUnits",
+		        "numRefills", "voided", "discontinueReason" };
 		assertThat(widget.getWidgets().size(), is(properties.length));
 		List<Widget> widgets = new ArrayList<>(widget.getWidgets().values());
 		for (int i = 0; i < widgets.size(); i++) {

--- a/api/src/main/java/org/openmrs/module/htmlformentry/HtmlFormEntryUtil.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/HtmlFormEntryUtil.java
@@ -719,26 +719,19 @@ public class HtmlFormEntryUtil {
 	/**
 	 * @return all drug orders for a patient, ordered by date, accounting for previous orders
 	 */
-	public static Map<Drug, List<DrugOrder>> getDrugOrdersForPatient(Patient patient, Set<Drug> drugs) {
-		Map<Drug, List<DrugOrder>> ret = new HashMap<>();
+	public static List<DrugOrder> getDrugOrdersForPatient(Patient patient, Set<Concept> concepts) {
+		List<DrugOrder> ret = new ArrayList<>();
 		List<Order> orders = Context.getOrderService().getAllOrdersByPatient(patient);
 		for (Order order : orders) {
 			order = HibernateUtil.getRealObjectFromProxy(order);
 			if (order instanceof DrugOrder && BooleanUtils.isNotTrue(order.getVoided())) {
 				DrugOrder drugOrder = (DrugOrder) order;
-				if (drugs == null || drugs.contains(drugOrder.getDrug())) {
-					List<DrugOrder> existing = ret.get(drugOrder.getDrug());
-					if (existing == null) {
-						existing = new ArrayList<>();
-						ret.put(drugOrder.getDrug(), existing);
-					}
-					existing.add(drugOrder);
+				if (concepts.contains(order.getConcept())) {
+					ret.add(drugOrder);
 				}
 			}
 		}
-		for (List<DrugOrder> l : ret.values()) {
-			sortDrugOrders(l);
-		}
+		sortDrugOrders(ret);
 		return ret;
 	}
 	

--- a/api/src/main/java/org/openmrs/module/htmlformentry/element/DrugOrderSubmissionElement.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/element/DrugOrderSubmissionElement.java
@@ -181,7 +181,7 @@ public class DrugOrderSubmissionElement implements HtmlGeneratorElement, FormSub
 			
 			DrugOrder newOrder = v.getNewDrugOrder();
 			DrugOrder previousOrder = v.getPreviousDrugOrder();
-			boolean voidPrevious = v.isVoidPreviousOrder();
+			boolean voidPrevious = false;
 			
 			// First we set some defaults on the new order
 			
@@ -198,7 +198,7 @@ public class DrugOrderSubmissionElement implements HtmlGeneratorElement, FormSub
 				
 				// Next, determine if this is a revision that should really be a void operation
 				// We do this by determining if the new order is a revision within the same encounter, with same date activated
-				if (!voidPrevious && previousOrder != null) {
+				if (previousOrder != null) {
 					if (encounter.equals(previousOrder.getEncounter())) { // Same encounter
 						if (isSameDrug(newOrder, previousOrder)) {
 							if (newOrder.getDateActivated().equals(previousOrder.getDateActivated())) { // Same date activated

--- a/api/src/main/java/org/openmrs/module/htmlformentry/element/DrugOrderSubmissionElement.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/element/DrugOrderSubmissionElement.java
@@ -200,7 +200,7 @@ public class DrugOrderSubmissionElement implements HtmlGeneratorElement, FormSub
 				// We do this by determining if the new order is a revision within the same encounter, with same date activated
 				if (!voidPrevious && previousOrder != null) {
 					if (encounter.equals(previousOrder.getEncounter())) { // Same encounter
-						if (newOrder.getDrug().equals(previousOrder.getDrug())) { // Same drug
+						if (isSameDrug(newOrder, previousOrder)) {
 							if (newOrder.getDateActivated().equals(previousOrder.getDateActivated())) { // Same date activated
 								voidPrevious = true;
 							}
@@ -234,7 +234,8 @@ public class DrugOrderSubmissionElement implements HtmlGeneratorElement, FormSub
 	}
 	
 	protected boolean isSameDrug(DrugOrder current, DrugOrder previous) {
-		boolean ret = areEqual(current.getDrug(), previous.getDrug());
+		boolean ret = areEqual(current.getConcept(), previous.getConcept());
+		ret = ret && areEqual(current.getDrug(), previous.getDrug());
 		ret = ret && areEqual(current.getDrugNonCoded(), previous.getDrugNonCoded());
 		return ret;
 	}

--- a/api/src/main/java/org/openmrs/module/htmlformentry/element/DrugOrderSubmissionElement.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/element/DrugOrderSubmissionElement.java
@@ -3,17 +3,15 @@ package org.openmrs.module.htmlformentry.element;
 import javax.servlet.http.HttpServletRequest;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.lang.BooleanUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.openmrs.CareSetting;
-import org.openmrs.Drug;
+import org.openmrs.Concept;
 import org.openmrs.DrugOrder;
 import org.openmrs.Encounter;
 import org.openmrs.FreeTextDosingInstructions;
@@ -28,6 +26,7 @@ import org.openmrs.module.htmlformentry.HtmlFormEntryUtil;
 import org.openmrs.module.htmlformentry.action.FormSubmissionControllerAction;
 import org.openmrs.module.htmlformentry.schema.DrugOrderAnswer;
 import org.openmrs.module.htmlformentry.schema.DrugOrderField;
+import org.openmrs.module.htmlformentry.schema.ObsFieldAnswer;
 import org.openmrs.module.htmlformentry.widget.DrugOrderWidget;
 import org.openmrs.module.htmlformentry.widget.DrugOrderWidgetConfig;
 import org.openmrs.module.htmlformentry.widget.DrugOrderWidgetValue;
@@ -102,47 +101,47 @@ public class DrugOrderSubmissionElement implements HtmlGeneratorElement, FormSub
 		for (DrugOrderWidgetValue v : drugOrders) {
 			DrugOrder drugOrder = v.getNewDrugOrder();
 			if (drugOrder != null) {
-				Drug drug = drugOrder.getDrug();
+				String fs = v.getFieldSuffix();
 				Order.Action action = drugOrder.getAction();
 				DrugOrder previousOrder = (DrugOrder) drugOrder.getPreviousOrder();
 				
 				// If not a discontinue Order, then validate dosing
 				if (action != Order.Action.DISCONTINUE) {
 					
-					handleRequiredField(ret, ctx, drug, "careSetting", drugOrder.getCareSetting());
+					handleRequiredField(ret, ctx, fs, "careSetting", drugOrder.getCareSetting());
 					
 					if (drugOrder.getDosingType() == SimpleDosingInstructions.class) {
-						handleRequiredField(ret, ctx, drug, "dose", drugOrder.getDose());
-						handleRequiredField(ret, ctx, drug, "doseUnits", drugOrder.getDoseUnits());
-						handleRequiredField(ret, ctx, drug, "route", drugOrder.getRoute());
-						handleRequiredField(ret, ctx, drug, "frequency", drugOrder.getFrequency());
+						handleRequiredField(ret, ctx, fs, "dose", drugOrder.getDose());
+						handleRequiredField(ret, ctx, fs, "doseUnits", drugOrder.getDoseUnits());
+						handleRequiredField(ret, ctx, fs, "route", drugOrder.getRoute());
+						handleRequiredField(ret, ctx, fs, "frequency", drugOrder.getFrequency());
 					} else if (drugOrder.getDosingType() == FreeTextDosingInstructions.class) {
 						String doseInstructions = drugOrder.getDosingInstructions();
-						handleRequiredField(ret, ctx, drug, "dosingInstructions", doseInstructions);
+						handleRequiredField(ret, ctx, fs, "dosingInstructions", doseInstructions);
 					} else {
-						String f = drugOrderWidget.getFormErrorField(ctx, drugOrder.getDrug(), "dosingType");
+						String f = drugOrderWidget.getFormErrorField(ctx, fs, "dosingType");
 						String dosingTypeError = HtmlFormEntryUtil.translate("htmlformentry.drugOrder.invalidDosingType");
 						ret.add(new FormSubmissionError(f, dosingTypeError));
 					}
 					
 					if (drugOrder.getCareSetting() != null) {
 						if (drugOrder.getCareSetting().getCareSettingType() == CareSetting.CareSettingType.OUTPATIENT) {
-							handleRequiredField(ret, ctx, drug, "quantity", drugOrder.getQuantity());
-							handleRequiredField(ret, ctx, drug, "quantityUnits", drugOrder.getQuantityUnits());
-							handleRequiredField(ret, ctx, drug, "numRefills", drugOrder.getNumRefills());
+							handleRequiredField(ret, ctx, fs, "quantity", drugOrder.getQuantity());
+							handleRequiredField(ret, ctx, fs, "quantityUnits", drugOrder.getQuantityUnits());
+							handleRequiredField(ret, ctx, fs, "numRefills", drugOrder.getNumRefills());
 						}
 					}
 					
 					if (drugOrder.getUrgency() == Order.Urgency.ON_SCHEDULED_DATE) {
-						handleRequiredField(ret, ctx, drug, "scheduledDate", drugOrder.getScheduledDate());
+						handleRequiredField(ret, ctx, fs, "scheduledDate", drugOrder.getScheduledDate());
 					}
 					
 					if (drugOrder.getDuration() != null) {
-						handleRequiredField(ret, ctx, drug, "durationUnits", drugOrder.getDurationUnits());
+						handleRequiredField(ret, ctx, fs, "durationUnits", drugOrder.getDurationUnits());
 					}
 					
 					if (drugOrder.getQuantity() != null) {
-						handleRequiredField(ret, ctx, drug, "quantityUnits", drugOrder.getQuantityUnits());
+						handleRequiredField(ret, ctx, fs, "quantityUnits", drugOrder.getQuantityUnits());
 					}
 				}
 				
@@ -222,14 +221,14 @@ public class DrugOrderSubmissionElement implements HtmlGeneratorElement, FormSub
 	/**
 	 * Retrieves the drug orders for the patient for the specified drugs
 	 */
-	public Map<Drug, List<DrugOrder>> getDrugOrders(Patient patient, DrugOrderField drugOrderField) {
-		Map<Drug, List<DrugOrder>> ret = new HashMap<>();
-		if (patient != null && drugOrderField.getDrugOrderAnswers() != null) {
-			Set<Drug> drugs = new HashSet<>();
-			for (DrugOrderAnswer doa : drugOrderField.getDrugOrderAnswers()) {
-				drugs.add(doa.getDrug());
+	public List<DrugOrder> getDrugOrders(Patient patient, DrugOrderField drugOrderField) {
+		List<DrugOrder> ret = new ArrayList<>();
+		if (patient != null && drugOrderField.getConceptOptions() != null) {
+			Set<Concept> concepts = new HashSet<>();
+			for (ObsFieldAnswer a : drugOrderField.getConceptOptions()) {
+				concepts.add(a.getConcept());
 			}
-			ret = HtmlFormEntryUtil.getDrugOrdersForPatient(patient, drugs);
+			ret = HtmlFormEntryUtil.getDrugOrdersForPatient(patient, concepts);
 		}
 		return ret;
 	}
@@ -263,9 +262,10 @@ public class DrugOrderSubmissionElement implements HtmlGeneratorElement, FormSub
 		return OpenmrsUtil.nullSafeEquals(o1, o2);
 	}
 	
-	public void handleRequiredField(List<FormSubmissionError> ret, FormEntryContext ctx, Drug d, String prop, Object val) {
+	public void handleRequiredField(List<FormSubmissionError> ret, FormEntryContext ctx, String fieldSuffix, String prop,
+	        Object val) {
 		if (val == null || val.equals("")) {
-			String field = drugOrderWidget.getFormErrorField(ctx, d, prop);
+			String field = drugOrderWidget.getFormErrorField(ctx, fieldSuffix, prop);
 			addError(ret, field, "htmlformentry.error.required");
 		}
 	}

--- a/api/src/main/java/org/openmrs/module/htmlformentry/element/DrugOrderSubmissionElement.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/element/DrugOrderSubmissionElement.java
@@ -18,6 +18,7 @@ import org.openmrs.FreeTextDosingInstructions;
 import org.openmrs.Order;
 import org.openmrs.Patient;
 import org.openmrs.SimpleDosingInstructions;
+import org.openmrs.api.context.Context;
 import org.openmrs.module.htmlformentry.FormEntryContext;
 import org.openmrs.module.htmlformentry.FormEntryContext.Mode;
 import org.openmrs.module.htmlformentry.FormEntrySession;
@@ -124,12 +125,10 @@ public class DrugOrderSubmissionElement implements HtmlGeneratorElement, FormSub
 						ret.add(new FormSubmissionError(f, dosingTypeError));
 					}
 					
-					if (drugOrder.getCareSetting() != null) {
-						if (drugOrder.getCareSetting().getCareSettingType() == CareSetting.CareSettingType.OUTPATIENT) {
-							handleRequiredField(ret, ctx, fs, "quantity", drugOrder.getQuantity());
-							handleRequiredField(ret, ctx, fs, "quantityUnits", drugOrder.getQuantityUnits());
-							handleRequiredField(ret, ctx, fs, "numRefills", drugOrder.getNumRefills());
-						}
+					if (areQuantityFieldsRequired(drugOrder)) {
+						handleRequiredField(ret, ctx, fs, "quantity", drugOrder.getQuantity());
+						handleRequiredField(ret, ctx, fs, "quantityUnits", drugOrder.getQuantityUnits());
+						handleRequiredField(ret, ctx, fs, "numRefills", drugOrder.getNumRefills());
 					}
 					
 					if (drugOrder.getUrgency() == Order.Urgency.ON_SCHEDULED_DATE) {
@@ -252,6 +251,17 @@ public class DrugOrderSubmissionElement implements HtmlGeneratorElement, FormSub
 		ret = ret || !areEqual(current.getAsNeeded(), previous.getAsNeeded());
 		ret = ret || !areEqual(current.getAsNeededCondition(), previous.getAsNeededCondition());
 		return ret;
+	}
+	
+	protected boolean areQuantityFieldsRequired(DrugOrder drugOrder) {
+		if (drugOrder.getCareSetting() != null) {
+			if (drugOrder.getCareSetting().getCareSettingType() == CareSetting.CareSettingType.OUTPATIENT) {
+				String gpName = "drugOrder.requireOutpatientQuantity";
+				String gpVal = Context.getAdministrationService().getGlobalProperty(gpName, "true");
+				return "true".equalsIgnoreCase(gpVal);
+			}
+		}
+		return false;
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/module/htmlformentry/handler/DrugOrderTagAttributeDescriptor.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/handler/DrugOrderTagAttributeDescriptor.java
@@ -105,6 +105,11 @@ public class DrugOrderTagAttributeDescriptor extends AttributeDescriptor {
 			for (HtmlFormField field : schema.getAllFields()) {
 				if (field instanceof DrugOrderField) {
 					DrugOrderField f = (DrugOrderField) field;
+					if (f.getConceptOptions() != null) {
+						for (ObsFieldAnswer a : f.getConceptOptions()) {
+							addDependency(ret, Concept.class, a.getConcept());
+						}
+					}
 					if (f.getDrugOrderAnswers() != null) {
 						for (DrugOrderAnswer a : f.getDrugOrderAnswers()) {
 							addDependency(ret, Drug.class, a.getDrug());

--- a/api/src/main/java/org/openmrs/module/htmlformentry/handler/DrugOrderTagHandler.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/handler/DrugOrderTagHandler.java
@@ -95,6 +95,7 @@ public class DrugOrderTagHandler extends AbstractTagHandler {
 		PROPERTIES.put("frequency", OrderFrequency.class);
 		PROPERTIES.put("durationUnits", Concept.class);
 		PROPERTIES.put("quantityUnits", Concept.class);
+		PROPERTIES.put("orderReason", Concept.class);
 		PROPERTIES.put("discontinueReason", Concept.class);
 	}
 	
@@ -146,6 +147,7 @@ public class DrugOrderTagHandler extends AbstractTagHandler {
 		processEnumOptions(widgetConfig, "action", Order.Action.values(), null);
 		processCareSettingOptions(widgetConfig);
 		processOrderTypeOptions(widgetConfig);
+		processConceptOptions(widgetConfig, "orderReason");
 		processConceptOptions(widgetConfig, "doseUnits");
 		processConceptOptions(widgetConfig, "route");
 		processOrderFrequencyOptions(widgetConfig);

--- a/api/src/main/java/org/openmrs/module/htmlformentry/schema/DrugOrderField.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/schema/DrugOrderField.java
@@ -7,6 +7,8 @@ import org.openmrs.Concept;
 
 public class DrugOrderField implements HtmlFormField {
 	
+	private List<ObsFieldAnswer> conceptOptions = new ArrayList<>();
+	
 	private List<DrugOrderAnswer> drugOrderAnswers = new ArrayList<>();
 	
 	private List<CareSettingAnswer> careSettingAnswers = new ArrayList<>();
@@ -28,6 +30,21 @@ public class DrugOrderField implements HtmlFormField {
 	private List<ObsFieldAnswer> discontinuedReasonAnswers = new ArrayList<>();
 	
 	public DrugOrderField() {
+	}
+	
+	public List<ObsFieldAnswer> getConceptOptions() {
+		return conceptOptions;
+	}
+	
+	public void setConceptOptions(List<ObsFieldAnswer> conceptOptions) {
+		this.conceptOptions = conceptOptions;
+	}
+	
+	public void addConceptOption(ObsFieldAnswer a) {
+		if (conceptOptions == null) {
+			conceptOptions = new ArrayList<>();
+		}
+		conceptOptions.add(a);
 	}
 	
 	public List<DrugOrderAnswer> getDrugOrderAnswers() {

--- a/api/src/main/java/org/openmrs/module/htmlformentry/widget/DrugOrderWidget.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/widget/DrugOrderWidget.java
@@ -168,6 +168,7 @@ public class DrugOrderWidget implements Widget {
 		translations.addTranslation(prefix, "action.revise");
 		translations.addTranslation(prefix, "action.discontinue");
 		translations.addTranslation(prefix, "delete");
+		translations.addTranslation(prefix, "discontinueReason");
 		
 		// Add a section for each concept configured in the tag
 		for (ObsFieldAnswer conceptOption : widgetConfig.getDrugOrderField().getConceptOptions()) {

--- a/api/src/main/java/org/openmrs/module/htmlformentry/widget/DrugOrderWidget.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/widget/DrugOrderWidget.java
@@ -162,8 +162,12 @@ public class DrugOrderWidget implements Widget {
 		translations.addTranslation(prefix, "noOrders");
 		translations.addTranslation(prefix, "chooseDrug");
 		translations.addTranslation(prefix, "encounterDateChangeWarning");
+		translations.addTranslation(prefix, "action.new");
+		translations.addTranslation(prefix, "action.renew");
+		translations.addTranslation(prefix, "action.revise");
+		translations.addTranslation(prefix, "action.discontinue");
 		
-		// Add a section for each concept configured in the tag.  Hide these sections if appropriate
+		// Add a section for each concept configured in the tag
 		for (ObsFieldAnswer conceptOption : widgetConfig.getDrugOrderField().getConceptOptions()) {
 			Concept concept = conceptOption.getConcept();
 			String conceptId = concept.getId().toString();
@@ -186,12 +190,10 @@ public class DrugOrderWidget implements Widget {
 				}
 			}
 			
-			List<JsonObject> history = jsonConcept.getObjectArray("history");
-			
 			if (initialValue != null) {
 				for (DrugOrder d : getInitialValueForConcept(concept)) {
 					Order pd = d.getPreviousOrder();
-					JsonObject jho = new JsonObject();
+					JsonObject jho = jsonConfig.addObjectToArray("history");
 					jho.addString("orderId", d.getOrderId().toString());
 					jho.addString("encounterId", d.getEncounter().getEncounterId().toString());
 					jho.addString("previousOrderId", pd == null ? "" : pd.getOrderId().toString());
@@ -224,7 +226,6 @@ public class DrugOrderWidget implements Widget {
 					addToJsonObject(jho, "quantityUnits", d.getQuantityUnits());
 					addToJsonObject(jho, "numRefills", d.getNumRefills());
 					addToJsonObject(jho, "discontinueReason", d.getOrderReason());
-					history.add(jho);
 				}
 			}
 		}
@@ -353,11 +354,11 @@ public class DrugOrderWidget implements Widget {
 		StringBuilder ret = new StringBuilder();
 		String labelCode = attrs.getOrDefault(DrugOrderTagHandler.LABEL_ATTRIBUTE, "htmlformentry.drugOrder." + property);
 		String label = translate(labelCode);
-		ret.append("<div class=\"order-field ").append(property).append("\">");
-		ret.append("<div class=\"order-field-label ").append(property).append("\">");
+		ret.append("<div class=\"order-field order-").append(property).append("\">");
+		ret.append("<div class=\"order-field-label order-").append(property).append("\">");
 		ret.append(label);
 		ret.append("</div>");
-		ret.append("<div class=\"order-field-widget ").append(property);
+		ret.append("<div class=\"order-field-widget order-").append(property);
 		if (w instanceof RadioButtonsWidget) {
 			ret.append(" order-field-radio-group");
 		}

--- a/api/src/main/java/org/openmrs/module/htmlformentry/widget/DrugOrderWidget.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/widget/DrugOrderWidget.java
@@ -71,6 +71,7 @@ public class DrugOrderWidget implements Widget {
 		configureNumericWidget(context, "numRefills", false);
 		configureCheckboxWidget(context, "voided");
 		configureOptionWidget(context, "discontinueReason", "dropdown");
+		configureTextWidget(context, "discontinueReasonNonCoded");
 	}
 	
 	@Override
@@ -227,6 +228,7 @@ public class DrugOrderWidget implements Widget {
 					addToJsonObject(jho, "quantityUnits", d.getQuantityUnits());
 					addToJsonObject(jho, "numRefills", d.getNumRefills());
 					addToJsonObject(jho, "discontinueReason", d.getOrderReason());
+					addToJsonObject(jho, "discontinueReasonNonCoded", d.getOrderReasonNonCoded());
 				}
 			}
 		}
@@ -449,6 +451,7 @@ public class DrugOrderWidget implements Widget {
 					drugOrder.setNumRefills(parseValue(getValue(c, r, fs, "numRefills"), Integer.class));
 					if (action == Order.Action.DISCONTINUE) {
 						drugOrder.setOrderReason(parseValue(getValue(c, r, fs, "discontinueReason"), Concept.class));
+						drugOrder.setOrderReasonNonCoded(getValue(c, r, fs, "discontinueReasonNonCoded"));
 					}
 					v.setNewDrugOrder(drugOrder);
 				}

--- a/api/src/main/java/org/openmrs/module/htmlformentry/widget/DrugOrderWidget.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/widget/DrugOrderWidget.java
@@ -170,6 +170,8 @@ public class DrugOrderWidget implements Widget {
 		translations.addTranslation(prefix, "delete");
 		translations.addTranslation(prefix, "discontinueReason");
 		
+		List<JsonObject> historyArray = jsonConfig.getObjectArray("history");
+		
 		// Add a section for each concept configured in the tag
 		for (ObsFieldAnswer conceptOption : widgetConfig.getDrugOrderField().getConceptOptions()) {
 			Concept concept = conceptOption.getConcept();
@@ -196,7 +198,7 @@ public class DrugOrderWidget implements Widget {
 			if (initialValue != null) {
 				for (DrugOrder d : getInitialValueForConcept(concept)) {
 					Order pd = d.getPreviousOrder();
-					JsonObject jho = jsonConfig.addObjectToArray("history");
+					JsonObject jho = new JsonObject();
 					jho.addString("orderId", d.getOrderId().toString());
 					jho.addString("encounterId", d.getEncounter().getEncounterId().toString());
 					jho.addString("previousOrderId", pd == null ? "" : pd.getOrderId().toString());
@@ -230,6 +232,7 @@ public class DrugOrderWidget implements Widget {
 					addToJsonObject(jho, "numRefills", d.getNumRefills());
 					addToJsonObject(jho, "discontinueReason", d.getOrderReason());
 					addToJsonObject(jho, "discontinueReasonNonCoded", d.getOrderReasonNonCoded());
+					historyArray.add(jho);
 				}
 			}
 		}

--- a/api/src/main/java/org/openmrs/module/htmlformentry/widget/DrugOrderWidget.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/widget/DrugOrderWidget.java
@@ -385,6 +385,7 @@ public class DrugOrderWidget implements Widget {
 			if (action != null) {
 				JsonObject o = json.addObjectToArray("values");
 				o.addString("fieldSuffix", fs);
+				o.addString("action", action.name());
 				for (Widget w : widgets.values()) {
 					String fieldName = c.getFieldName(w) + fs;
 					JsonObject field = o.addObjectToArray("fields");

--- a/api/src/main/java/org/openmrs/module/htmlformentry/widget/DrugOrderWidgetValue.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/widget/DrugOrderWidgetValue.java
@@ -9,6 +9,8 @@ import org.openmrs.DrugOrder;
  */
 public class DrugOrderWidgetValue {
 	
+	private String fieldSuffix;
+	
 	private DrugOrder previousDrugOrder;
 	
 	private DrugOrder newDrugOrder;
@@ -16,6 +18,14 @@ public class DrugOrderWidgetValue {
 	private boolean voidPreviousOrder;
 	
 	public DrugOrderWidgetValue() {
+	}
+	
+	public String getFieldSuffix() {
+		return fieldSuffix;
+	}
+	
+	public void setFieldSuffix(String fieldSuffix) {
+		this.fieldSuffix = fieldSuffix;
 	}
 	
 	public DrugOrder getPreviousDrugOrder() {

--- a/api/src/main/java/org/openmrs/module/htmlformentry/widget/DrugOrderWidgetValue.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/widget/DrugOrderWidgetValue.java
@@ -15,8 +15,6 @@ public class DrugOrderWidgetValue {
 	
 	private DrugOrder newDrugOrder;
 	
-	private boolean voidPreviousOrder;
-	
 	public DrugOrderWidgetValue() {
 	}
 	
@@ -42,13 +40,5 @@ public class DrugOrderWidgetValue {
 	
 	public void setNewDrugOrder(DrugOrder newDrugOrder) {
 		this.newDrugOrder = newDrugOrder;
-	}
-	
-	public boolean isVoidPreviousOrder() {
-		return voidPreviousOrder;
-	}
-	
-	public void setVoidPreviousOrder(boolean voidPreviousOrder) {
-		this.voidPreviousOrder = voidPreviousOrder;
 	}
 }

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -77,7 +77,8 @@ htmlformentry.drugOrder.action.renew                     = Renew
 htmlformentry.drugOrder.action.discontinue               = Discontinue
 htmlformentry.drugOrder.careSetting                      = Care Setting
 htmlformentry.drugOrder.orderType                        = Order Type
-htmlformentry.drugOrder.drug                             = Drug
+htmlformentry.drugOrder.concept                          = Drug
+htmlformentry.drugOrder.drug                             = Formulation
 htmlformentry.drugOrder.dosingType                       = Dosing Type
 htmlformentry.drugOrder.dosingType.simple                = Simple
 htmlformentry.drugOrder.dosingType.freetext              = Free Text
@@ -115,6 +116,7 @@ htmlformentry.drugOrder.dispense                         = Dispense
 htmlformentry.drugOrder.drugName                         = Drug Name
 htmlformentry.drugOrder.formulation                      = Formulation
 htmlformentry.drugOrder.drugNonCoded                     = Other Formulation
+htmlformentry.drugOrder.delete                           = Delete
 
 htmlformentry.drugOrderError.previousOrderRequired       = You must specify an existing order in order to revise it
 htmlformentry.drugOrderError.drugChangedForRevision      = No drug changes are permitted when issuing a revise order

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -101,6 +101,7 @@ htmlformentry.drugOrder.quantity                         = Quantity
 htmlformentry.drugOrder.quantityUnits                    = Quantity Units
 htmlformentry.drugOrder.numRefills                       = Number of Refills
 htmlformentry.drugOrder.discontinueReason                = Discontinue Reason
+htmlformentry.drugOrder.discontinueReasonNonCoded        = Other Discontinue Reason
 htmlformentry.drugOrder.voided                           = Voided
 htmlformentry.drugOrder.present                          = Present
 htmlformentry.drugOrder.previousOrder                    = Previous Order

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -103,6 +103,7 @@ htmlformentry.drugOrder.discontinueReason                = Discontinue Reason
 htmlformentry.drugOrder.voided                           = Voided
 htmlformentry.drugOrder.present                          = Present
 htmlformentry.drugOrder.previousOrder                    = Previous Order
+htmlformentry.drugOrder.active                           = Active
 htmlformentry.drugOrder.noOrders                         = No Orders
 htmlformentry.drugOrder.chooseDrug                       = Choose Drug
 htmlformentry.drugOrder.encounterDateChangeWarning       = Warning, changing the encounter date will reset any newly entered drug order fields and will not automatically change the date of previously saved orders.  Please review drug orders for accuracy.
@@ -111,6 +112,8 @@ htmlformentry.drugOrder.starting                         = Starting
 htmlformentry.drugOrder.for                              = For
 htmlformentry.drugOrder.until                            = Until
 htmlformentry.drugOrder.dispense                         = Dispense
+htmlformentry.drugOrder.drugName                         = Drug Name
+htmlformentry.drugOrder.formulation                      = Formulation
 
 htmlformentry.drugOrderError.previousOrderRequired       = You must specify an existing order in order to revise it
 htmlformentry.drugOrderError.drugChangedForRevision      = No drug changes are permitted when issuing a revise order

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -100,6 +100,7 @@ htmlformentry.drugOrder.durationUnits                    = Duration Units
 htmlformentry.drugOrder.quantity                         = Quantity
 htmlformentry.drugOrder.quantityUnits                    = Quantity Units
 htmlformentry.drugOrder.numRefills                       = Number of Refills
+htmlformentry.drugOrder.orderReason                      = Order Reason
 htmlformentry.drugOrder.discontinueReason                = Discontinue Reason
 htmlformentry.drugOrder.discontinueReasonNonCoded        = Other Discontinue Reason
 htmlformentry.drugOrder.voided                           = Voided

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -71,10 +71,10 @@ htmlformentry.form.complex.download                      = Download
 htmlformentry.form.complex.delete                        = Delete existing file
 
 htmlformentry.drugOrder.action                           = Order Action
-htmlformentry.drugOrder.action.new                       = New Order
-htmlformentry.drugOrder.action.revise                    = Revise Order
-htmlformentry.drugOrder.action.renew                     = Renew Order
-htmlformentry.drugOrder.action.discontinue               = Discontinue Order
+htmlformentry.drugOrder.action.new                       = New
+htmlformentry.drugOrder.action.revise                    = Revise
+htmlformentry.drugOrder.action.renew                     = Renew
+htmlformentry.drugOrder.action.discontinue               = Discontinue
 htmlformentry.drugOrder.careSetting                      = Care Setting
 htmlformentry.drugOrder.orderType                        = Order Type
 htmlformentry.drugOrder.drug                             = Drug
@@ -114,6 +114,7 @@ htmlformentry.drugOrder.until                            = Until
 htmlformentry.drugOrder.dispense                         = Dispense
 htmlformentry.drugOrder.drugName                         = Drug Name
 htmlformentry.drugOrder.formulation                      = Formulation
+htmlformentry.drugOrder.drugNonCoded                     = Other Formulation
 
 htmlformentry.drugOrderError.previousOrderRequired       = You must specify an existing order in order to revise it
 htmlformentry.drugOrderError.drugChangedForRevision      = No drug changes are permitted when issuing a revise order

--- a/api/src/test/java/org/openmrs/module/htmlformentry/tester/DrugOrderFieldTester.java
+++ b/api/src/test/java/org/openmrs/module/htmlformentry/tester/DrugOrderFieldTester.java
@@ -36,7 +36,7 @@ public class DrugOrderFieldTester {
 	}
 	
 	public DrugOrderFieldTester setField(String property, String value) {
-		String formField = formSessionTester.getFormField("order-field-label " + property) + suffix;
+		String formField = formSessionTester.getFormField("order-field-label order-" + property) + suffix;
 		formSessionTester.setFormField(formField, value);
 		return this;
 	}

--- a/api/src/test/java/org/openmrs/module/htmlformentry/tester/DrugOrderFieldTester.java
+++ b/api/src/test/java/org/openmrs/module/htmlformentry/tester/DrugOrderFieldTester.java
@@ -1,29 +1,48 @@
 package org.openmrs.module.htmlformentry.tester;
 
+import org.openmrs.Drug;
 import org.openmrs.FreeTextDosingInstructions;
 import org.openmrs.SimpleDosingInstructions;
+import org.openmrs.api.context.Context;
 
 public class DrugOrderFieldTester {
 	
-	private final Integer drugId;
+	private static int nextFieldNum = 0;
+	
+	private final String suffix;
 	
 	private final FormSessionTester formSessionTester;
 	
-	private DrugOrderFieldTester(Integer drugId, FormSessionTester formSessionTester) {
-		this.drugId = drugId;
+	private DrugOrderFieldTester(String suffix, FormSessionTester formSessionTester) {
+		this.suffix = suffix;
 		this.formSessionTester = formSessionTester;
 	}
 	
+	public static DrugOrderFieldTester forDrug(Integer drugId, String suffix, FormSessionTester formSessionTester) {
+		Drug drug = Context.getConceptService().getDrug(drugId);
+		DrugOrderFieldTester tester = new DrugOrderFieldTester(suffix, formSessionTester);
+		tester.setField("concept", drug.getConcept().getConceptId().toString());
+		tester.setField("drug", drugId.toString());
+		return tester;
+	}
+	
 	public static DrugOrderFieldTester forDrug(Integer drugId, FormSessionTester formSessionTester) {
-		DrugOrderFieldTester tester = new DrugOrderFieldTester(drugId, formSessionTester);
-		formSessionTester.setFieldWithLabel("order-field-label drug", drugId.toString());
+		Drug drug = Context.getConceptService().getDrug(drugId);
+		String nextSuffix = "_" + drug.getConcept().getConceptId() + "_" + nextFieldNum++;
+		DrugOrderFieldTester tester = new DrugOrderFieldTester(nextSuffix, formSessionTester);
+		tester.setField("concept", drug.getConcept().getConceptId().toString());
+		tester.setField("drug", drugId.toString());
 		return tester;
 	}
 	
 	public DrugOrderFieldTester setField(String property, String value) {
-		String formField = formSessionTester.getFormField("order-field-label " + property) + "_" + drugId;
+		String formField = formSessionTester.getFormField("order-field-label " + property) + suffix;
 		formSessionTester.setFormField(formField, value);
 		return this;
+	}
+	
+	public String getSuffix() {
+		return suffix;
 	}
 	
 	public DrugOrderFieldTester previousOrder(String val) {

--- a/omod/src/main/webapp/resources/drugOrderWidget.css
+++ b/omod/src/main/webapp/resources/drugOrderWidget.css
@@ -104,7 +104,7 @@
 }
 
 .order-view-field.order-view-discontinue-reason {
-	font-weight:bold; padding-left:20px;
+	font-weight:bold;
 }
 
 .order-view-different-encounter {
@@ -112,7 +112,7 @@
 }
 
 .drugorders-selector-section {
-	padding-top: 5px;
+	margin: 10px;
 }
 
 .order-instructions {
@@ -152,6 +152,10 @@
 
 .order-view-field {
 	padding-right: 10px;
+}
+
+.order-action-section {
+	margin: 10px;
 }
 
 .order-action-button {

--- a/omod/src/main/webapp/resources/drugOrderWidget.css
+++ b/omod/src/main/webapp/resources/drugOrderWidget.css
@@ -75,6 +75,10 @@
 	display: inline-block;
 }
 
+.order-view-section.order-view-reasons {
+	display: inline-block;
+}
+
 .order-view-section.order-view-dates {
 	display: inline-block;
 }

--- a/omod/src/main/webapp/resources/drugOrderWidget.css
+++ b/omod/src/main/webapp/resources/drugOrderWidget.css
@@ -4,8 +4,34 @@
 	border: 1px dotted black;
 }
 
+.drugorders-drug-remove-action {
+	display: inline-block;
+	padding-left: 10px;
+	font-weight: bold;
+}
+
 .drugorders-drug-details {
 	font-weight: bold;
+	display: inline-block;
+}
+
+.drugorders-drug-details-concept {
+	display: inline-block;
+}
+
+.drugorders-drug-details-concept:after {
+	content: " -- ";
+	white-space: pre;
+}
+
+.drugorders-drug-details-drug {
+	display: inline-block;
+	font-style: italic;
+}
+
+.drugorders-drug-details-drugNonCoded {
+	display: inline-block;
+	font-style: italic;
 }
 
 .drugorders-drug-history {
@@ -18,8 +44,22 @@
 	margin: 10px;
 }
 
+.drugorders-order-form-concept {
+	font-weight: bold;
+}
+
 .drugorders-order-history-item {
 	display: block;
+}
+
+.drugorders-order-history-item.value {
+	font-weight: normal;
+}
+
+.drugorders-drug-order-history-separator {
+	margin-top: 5px;
+	border-bottom: 1px dotted black;
+	margin-bottom: 5px;
 }
 
 .order-view-section {

--- a/omod/src/main/webapp/resources/drugOrderWidget.css
+++ b/omod/src/main/webapp/resources/drugOrderWidget.css
@@ -115,7 +115,7 @@
 	padding-top: 5px;
 }
 
-.instructions {
+.order-instructions {
 	font-size: 1.0em;
 }
 
@@ -152,4 +152,28 @@
 
 .order-view-field {
 	padding-right: 10px;
+}
+
+.order-action-button {
+	display:inline-block;
+	color:#444;
+	border:1px solid #CCC;
+	background:#DDD;
+	box-shadow: 0 0 5px -1px rgba(0,0,0,0.2);
+	cursor:pointer;
+	vertical-align:middle;
+	max-width: 100px;
+	padding: 2px;
+	margin-right: 5px;
+	text-align: center;
+}
+.order-action-button:active {
+	font-weight: bold;
+	box-shadow: 0 0 5px -1px rgba(0,0,0,0.6);
+}
+
+.drugorders-selected-action {
+	background-color: #2200ff;
+	color: white;
+	font-weight: bold;
 }

--- a/omod/src/main/webapp/resources/drugOrderWidget.css
+++ b/omod/src/main/webapp/resources/drugOrderWidget.css
@@ -19,19 +19,24 @@
 	display: inline-block;
 }
 
-.drugorders-drug-details-concept:after {
-	content: " -- ";
-	white-space: pre;
-}
-
 .drugorders-drug-details-drug {
 	display: inline-block;
 	font-style: italic;
 }
 
+.drugorders-drug-details-drug:before {
+	content: " -- ";
+	white-space: pre;
+}
+
 .drugorders-drug-details-drugNonCoded {
 	display: inline-block;
 	font-style: italic;
+}
+
+.drugorders-drug-details-drugNonCoded:before {
+	content: " -- ";
+	white-space: pre;
 }
 
 .drugorders-drug-history {

--- a/omod/src/main/webapp/resources/drugOrderWidget.css
+++ b/omod/src/main/webapp/resources/drugOrderWidget.css
@@ -162,7 +162,7 @@
 	box-shadow: 0 0 5px -1px rgba(0,0,0,0.2);
 	cursor:pointer;
 	vertical-align:middle;
-	max-width: 100px;
+	max-width: 200px;
 	padding: 2px;
 	margin-right: 5px;
 	text-align: center;

--- a/omod/src/main/webapp/resources/drugOrderWidget.js
+++ b/omod/src/main/webapp/resources/drugOrderWidget.js
@@ -261,7 +261,11 @@
         // Render the appropriate fields
         drugOrderWidget.enableDateWidgets(config, $orderForm, encDate);
         if (action === 'DISCONTINUE') {
-            $orderForm.find('.order-discontinueReason').show();
+            var $discontinueReasonSelect = $orderForm.find('.order-field-widget.order-discontinueReason').find('select');
+            if ($discontinueReasonSelect.find('option').length > 1) {
+                $orderForm.find('.order-discontinueReason').show();
+            }
+            $orderForm.find('.order-discontinueReasonNonCoded').show();
         } else if (action === 'RENEW') {
             drugOrderWidget.enableDrugOrderDurationWidgets($orderForm);
         } else if (action === 'REVISE' || action === 'NEW') {
@@ -519,6 +523,7 @@
         if (isDiscontinue) {
             var $discontinueSection = $('<div class="order-view-section order-view-discontinue"></div>');
             $discontinueSection.append('<div class="order-view-field order-view-discontinue-reason">' + d.discontinueReason.display + '</div>');
+            $discontinueSection.append('<div class="order-view-field order-view-discontinue-reason-non-coded">' + d.discontinueReasonNonCoded.display + '</div>');
             $ret.append($discontinueSection);
         }
         else {

--- a/omod/src/main/webapp/resources/drugOrderWidget.js
+++ b/omod/src/main/webapp/resources/drugOrderWidget.js
@@ -178,6 +178,8 @@
         $drugSection.append($historySection);
         $historySection.empty();
 
+        $historySection.append(drugOrderWidget.formatOrderable(drugOrder));
+
         // If the order was placed in this encounter, and it was a revision of a previous order, render the previous order
         if (drugOrderWidget.shouldRenderPreviousOrder(drugOrder, config)) {
             var prevOrder = drugOrderWidget.getOrder(drugOrder.previousOrderId, config.history);
@@ -302,11 +304,13 @@
             var $drugOrderSection = drugOrderWidget.addDrugOrderSection(config);
             var $orderForm = drugOrderWidget.constructOrderForm($drugOrderSection, idSuffix, config, 'NEW');
 
-            var $removeLink = $('<div class="order-action-button">' + config.translations.delete + '</div>');
-            $removeLink.click(function(event) {
+            var $actionSection = $('<div class="order-action-section"></div>');
+            var $deleteAction = $('<div class="order-action-button">' + config.translations.delete + '</div>');
+            $deleteAction.click(function(event) {
                 $drugOrderSection.remove();
             });
-            $drugOrderSection.append($removeLink);
+            $actionSection.append($deleteAction);
+            $drugOrderSection.append($actionSection);
 
             drugOrderWidget.enableDrugSelector(config, $orderForm);
             drugOrderWidget.enableContextWidgets(config, $orderForm);
@@ -469,19 +473,21 @@
         $orderForm.find('.order-field-widget.order-numRefills').find(':input').val(drugOrder.numRefills.value);
     }
 
+    drugOrderWidget.formatOrderable = function(drugOrder) {
+        // Render drug name details
+        var $ret = $('<div class="order-view-section drugorders-drug-details"></div>');
+        $ret.append('<div class="drugorders-drug-details-concept">' + drugOrder.concept.display  + '</div>');
+        if (drugOrder.drug.value !== '') {
+            $ret.append('<div class="drugorders-drug-details-drug">' + drugOrder.drug.display + '</div>');
+        }
+        if (drugOrder.drugNonCoded.value !== '') {
+            $ret.append('<div class="drugorders-drug-details-drugNonCoded">' + drugOrder.drugNonCoded.display + '</div>');
+        }
+        return $ret;
+    }
+
     drugOrderWidget.formatDrugOrder = function(d, encDate, config) {
         var $ret = $('<div class="drugorders-order-history-item"></div>');
-
-        // Render drug name details
-        var $drugDetailsSection = $('<div class="order-view-section drugorders-drug-details"></div>');
-        $drugDetailsSection.append('<div class="drugorders-drug-details-concept">' + d.concept.display  + '</div>');
-        if (d.drug.value !== '') {
-            $drugDetailsSection.append('<div class="drugorders-drug-details-drug">' + d.drug.display + '</div>');
-        }
-        if (d.drugNonCoded.value !== '') {
-            $drugDetailsSection.append('<div class="drugorders-drug-details-drugNonCoded">' + d.drugNonCoded.display + '</div>');
-        }
-        $ret.append($drugDetailsSection);
 
         var $existingActionSection = $('<div class="order-view-section order-view-action"></div>');
         var inCurrentEncounter = drugOrderWidget.isOrderInCurrentEncounter(d, config);
@@ -522,8 +528,8 @@
 
         if (isDiscontinue) {
             var $discontinueSection = $('<div class="order-view-section order-view-discontinue"></div>');
-            $discontinueSection.append('<div class="order-view-field order-view-discontinue-reason">' + d.discontinueReason.display + '</div>');
-            $discontinueSection.append('<div class="order-view-field order-view-discontinue-reason-non-coded">' + d.discontinueReasonNonCoded.display + '</div>');
+            $discontinueSection.append('<div class="order-view-field order-view-discontinue-reason-label">' + config.translations.discontinueReason + ': </div>');
+            $discontinueSection.append('<div class="order-view-field order-view-discontinue-reason">' + d.discontinueReason.display + d.discontinueReasonNonCoded.display + '</div>');
             $ret.append($discontinueSection);
         }
         else {

--- a/omod/src/main/webapp/resources/drugOrderWidget.js
+++ b/omod/src/main/webapp/resources/drugOrderWidget.js
@@ -133,7 +133,7 @@
         // Set up watch for an encounter date change.  If date changes, re-initialize all drug sections
         var $encDateHidden = $('#encounterDate').find('input[type="hidden"]');
         $encDateHidden.change(function() {
-            if ($('.drugorders-order-form').length > 0) {
+            if ($('.drugorders-order-form').length > 1) { // More than 1, since the template is present
                 alert(config.translations.encounterDateChangeWarning);
             }
             drugOrderWidget.renderDrugOrdersForRevision(config);

--- a/omod/src/main/webapp/resources/drugOrderWidget.js
+++ b/omod/src/main/webapp/resources/drugOrderWidget.js
@@ -34,8 +34,8 @@
         return $('.drugorders-drug-section').length;
     }
 
-    drugOrderWidget.nextOrderFormIndex = function() {
-        return $('.drugorders-order-form').length;
+    drugOrderWidget.nextActionButtonIndex = function() {
+        return $('.order-action-button').length;
     }
 
     drugOrderWidget.isOrderInCurrentEncounter = function(order, config) {
@@ -218,11 +218,10 @@
     /**
      * Clones the order form template and replaces all the the ids and names as appropriate
      */
-    drugOrderWidget.constructOrderForm = function($sectionToAppendTo, config, action) {
+    drugOrderWidget.constructOrderForm = function($sectionToAppendTo, idSuffix, config, action) {
 
         // Clone the order form template, ensuring ids and names of widgets are configured for this specific drug
         var $orderForm = $('#' + config.fieldName + '_template').clone();
-        var idSuffix = '_' + drugOrderWidget.nextOrderFormIndex();
         $orderForm.find("[id]").add($orderForm).each(function () {
             this.id = this.id + idSuffix;
         });
@@ -284,15 +283,20 @@
         return $orderForm;
     }
 
+    drugOrderWidget.createActionButton = function(idSuffix, action, label) {
+        return $('<div id="order-action-button-' + action + idSuffix + '" class="order-action-button">' + label + '</div>');
+    }
+
     /**
      * The purpose of this function is to construct selectors and form for entering a NEW order
      */
     drugOrderWidget.createNewOrderSection = function(config) {
         var $actionOption = drugOrderWidget.getActionOption(config, 'NEW');
-        var $newButton = $('<div class="order-action-button">' + $actionOption.html() + '</div>');
+        var idSuffix = '_' + drugOrderWidget.nextActionButtonIndex();
+        var $newButton = drugOrderWidget.createActionButton(idSuffix, 'NEW', $actionOption.html());
         $newButton.click(function () {
             var $drugOrderSection = drugOrderWidget.addDrugOrderSection(config);
-            var $orderForm = drugOrderWidget.constructOrderForm($drugOrderSection, config, 'NEW');
+            var $orderForm = drugOrderWidget.constructOrderForm($drugOrderSection, idSuffix, config, 'NEW');
 
             var $removeLink = $('<div class="order-action-button">' + config.translations.delete + '</div>');
             $removeLink.click(function(event) {
@@ -317,8 +321,9 @@
         var orderActions = drugOrderWidget.getSupportedActions(drugOrder, config, encDate);
         orderActions.forEach(function(action) {
             var $actionOption = drugOrderWidget.getActionOption(config, action);
-            var $actionButton = $('<div class="order-action-button">' + $actionOption.html() + '</div>');
-            $actionButton.click(function(event) {
+            var idSuffix = '_' + drugOrderWidget.nextActionButtonIndex();
+            var $actionButton = drugOrderWidget.createActionButton(idSuffix, action, $actionOption.html());
+            $actionButton.click(function() {
                 var $orderForm = $orderActionForms.find('.drugorders-order-form');
                 if ($orderForm.length > 0) {
                     $orderForm.remove();
@@ -326,7 +331,7 @@
                 }
                 else {
                     $actionButton.addClass('drugorders-selected-action');
-                    $orderForm = drugOrderWidget.constructOrderForm($orderActionForms, config, action);
+                    $orderForm = drugOrderWidget.constructOrderForm($orderActionForms, idSuffix, config, action);
                     drugOrderWidget.populateOrderForm(config, $orderForm, drugOrder);
                     $orderForm.show();
                 }
@@ -559,8 +564,9 @@
             data.values.forEach(function (val) {
                 var config = data.config;
                 var fieldSuffix = val.fieldSuffix;
-                var $orderForm = $('#' + config.fieldName + '_template' + fieldSuffix);
-                $orderForm.show();
+                var action = val.action;
+                var $actionButton = $('#order-action-button-' + action + fieldSuffix);
+                $actionButton.click();
                 val.fields.forEach(function (field) {
                     setValueByName(field.name, field.value);
                 });

--- a/omod/src/main/webapp/resources/drugOrderWidget.js
+++ b/omod/src/main/webapp/resources/drugOrderWidget.js
@@ -380,7 +380,16 @@
     drugOrderWidget.enableContextWidgets = function(config, $orderForm) {
         if (config.hasTemplate === 'false') {
             $orderForm.find('.order-careSetting').show();
-            $orderForm.find('.order-orderType').show();
+
+            var $orderTypeSelect = $orderForm.find('.order-field-widget.order-orderReason').find(':input');
+            if ($orderTypeSelect.find('option').length > 1) {
+                $orderForm.find('.order-orderType').show();
+            }
+
+            var $orderReasonSelect = $orderForm.find('.order-field-widget.order-orderReason').find(':input');
+            if ($orderReasonSelect.find('option').length > 1) {
+                $orderForm.find('.order-orderReason').show();
+            }
         }
     }
 
@@ -454,6 +463,8 @@
         $orderForm.find('.order-field-widget.order-concept').find(':input').val(drugOrder.concept.value);
         $orderForm.find('.order-field-widget.order-drug').find(':input').val(drugOrder.drug.value);
         $orderForm.find('.order-field-widget.order-drugNonCoded').find(':input').val(drugOrder.drugNonCoded.value);
+        $orderForm.find('.order-field-widget.order-orderReason').find(':input').val(drugOrder.orderReason.value);
+        $orderForm.find('.order-field-widget.order-orderReasonNonCoded').find(':input').val(drugOrder.orderReasonNonCoded.value);
         $orderForm.find('.order-field-widget.order-careSetting').find(':input').val(drugOrder.careSetting.value);
         $orderForm.find('.order-field-widget.order-dosingType').find(':input[value="' + drugOrder.dosingType.value + '"]').click();
         $orderForm.find('.order-field-widget.order-orderType').find(':input').val(drugOrder.orderType.value);
@@ -489,7 +500,10 @@
     drugOrderWidget.formatDrugOrder = function(d, encDate, config) {
         var $ret = $('<div class="drugorders-order-history-item"></div>');
 
-        var $existingActionSection = $('<div class="order-view-section order-view-action"></div>');
+        var isActive = drugOrderWidget.isOrderActive(d, encDate);
+        $ret.addClass(isActive ? "order-view-active" : "order-view-inactive")
+
+        var $existingActionSection = $('<div class="order-view-section order-view-field order-view-action"></div>');
         var inCurrentEncounter = drugOrderWidget.isOrderInCurrentEncounter(d, config);
         if (!inCurrentEncounter) {
             $ret.addClass('order-view-different-encounter');
@@ -505,9 +519,14 @@
             $ret.addClass('value');
             $existingActionSection.append(d.action.display);
         }
-        var isActive = drugOrderWidget.isOrderActive(d, encDate);
-        $ret.addClass(isActive ? "order-view-active" : "order-view-inactive")
         $ret.append($existingActionSection);
+
+        var $reasonSection = $('<div class="order-view-section order-view-reasons"></div>');
+        if (d.orderReason.display !== '' || d.orderReasonNonCoded.display !== '') {
+            $reasonSection.append('<div class="order-view-field order-view-orderReason-label">' + config.translations.for + '</div>');
+            $reasonSection.append('<div class="order-view-field order-view-orderReason">' + d.orderReason.display + d.orderReasonNonCoded.display + '</div>');
+        }
+        $ret.append($reasonSection);
 
         var isDiscontinue = (d.action.value === 'DISCONTINUE');
 

--- a/omod/src/main/webapp/resources/drugOrderWidget.js
+++ b/omod/src/main/webapp/resources/drugOrderWidget.js
@@ -385,11 +385,10 @@
             if ($orderTypeSelect.find('option').length > 1) {
                 $orderForm.find('.order-orderType').show();
             }
-
-            var $orderReasonSelect = $orderForm.find('.order-field-widget.order-orderReason').find(':input');
-            if ($orderReasonSelect.find('option').length > 1) {
-                $orderForm.find('.order-orderReason').show();
-            }
+        }
+        var $orderReasonSelect = $orderForm.find('.order-field-widget.order-orderReason').find(':input');
+        if ($orderReasonSelect.find('option').length > 1) {
+            $orderForm.find('.order-orderReason').show();
         }
     }
 


### PR DESCRIPTION
This involves relatively significant rewrite of the still unreleased new drug order tag.  It aims to address the following previous limitations:

* Previously you could only have 1 order per drug, and drug was required.  Now you can have several orders for the same drug, and instead of limiting to "drug", we now support ordering a) concept, b) optional coded drug, c) optional non-coded drug, for each order.

* Adds ability to set non-coded discontinue reason

* Adds new formatting (styled buttons) rather than a drop-down list for choosing the order action, and makes the selection of actions more intuitive.

* Fixes a few issues around CSS styling due to overloading of existing class names (voided, action) inadvertently

* Removes support for the "checkbox" format of rendering the tag.

* Adds support for "orderReason" and "orderReasonNonCoded" properties

* Remove "voided" checkbox that was never implemented correctly