### PR TITLE
HTML-561 Obs group support for Signs and Symptoms construct

### DIFF
--- a/api-tests/src/test/java/org/openmrs/module/htmlformentry/ObsGroupTagTest.java
+++ b/api-tests/src/test/java/org/openmrs/module/htmlformentry/ObsGroupTagTest.java
@@ -3,19 +3,33 @@ package org.openmrs.module.htmlformentry;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.Map;
 
+import junit.framework.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.openmrs.Encounter;
+import org.openmrs.Patient;
+import org.openmrs.Person;
+import org.openmrs.RelationshipType;
 import org.openmrs.api.ConceptService;
+import org.openmrs.api.context.Context;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.mock.web.MockHttpServletRequest;
 
 public class ObsGroupTagTest extends BaseHtmlFormEntryTest {
 	
 	@Autowired
 	@Qualifier("conceptService")
 	ConceptService conceptService;
+	
+	@Before
+	public void before() throws Exception {
+		executeVersionedDataSet("org/openmrs/module/htmlformentry/data/RegressionTest-data-openmrs-2.1.xml");
+	}
 	
 	@Test
 	public void testEmptyObsGroupIsNotDisplayed() throws Exception {
@@ -56,6 +70,156 @@ public class ObsGroupTagTest extends BaseHtmlFormEntryTest {
 			public void testViewingEncounter(Encounter encounter, String html) {
 				assertTrue(html.contains("It is displayed."));
 			}
+		}.run();
+	}
+	
+	@Test
+	public void testObsGroupContextObsDoesNotDisplay() throws Exception {
+		new RegressionTestHelper() {
+			
+			@Override
+			public String getFormName() {
+				return "obsGroupWithContextObs";
+			}
+			
+			public void testBlankFormHtml(String html) {
+				String obsGroupHtml = html.split("obsgroup start")[1];
+				String[] tags = obsGroupHtml.split("<");
+				ArrayList<String> inputTags = new ArrayList<String>();
+				for (String tag : tags) {
+					if (tag.contains("input") && tag.contains("type=\"text\"")) {
+						inputTags.add(tag);
+					}
+				}
+				assertTrue("Should display only one input box within the obs group, found " + inputTags.size() + ": "
+				        + obsGroupHtml,
+				    inputTags.size() == 1);
+			}
+		};
+	}
+	
+	@Test
+	public void testObsGroupSubmitsContextObs() throws Exception {
+		final Date date = new Date();
+		new RegressionTestHelper() {
+			
+			@Override
+			public String getFormName() {
+				return "obsGroupWithContextObs";
+			}
+			
+			@Override
+			public String[] widgetLabels() {
+				return new String[] { "Date:", "Location:", "Provider:", "Value:" };
+			}
+			
+			@Override
+			public void setupRequest(MockHttpServletRequest request, Map<String, String> widgets) {
+				request.addParameter(widgets.get("Date:"), dateAsString(new Date()));
+				request.addParameter(widgets.get("Location:"), "2");
+				request.addParameter(widgets.get("Provider:"), "502");
+				request.addParameter(widgets.get("Value:"), "Bee stings");
+			}
+			
+			@Override
+			public void testResults(SubmissionResults results) {
+				results.assertNoErrors();
+				results.assertEncounterCreated();
+				results.assertObsGroupCreatedCount(1);
+				results.assertObsGroupCreated(23, 80000, "Bee stings", 1000, conceptService.getConcept(1004));
+			}
+		}.run();
+	}
+	
+	@Test
+	public void testObsGroupDoesNotSaveContextObsWhenEmpty() throws Exception {
+		final Date date = new Date();
+		new RegressionTestHelper() {
+			
+			@Override
+			public String getFormName() {
+				return "obsGroupWithContextObs";
+			}
+			
+			@Override
+			public String[] widgetLabels() {
+				return new String[] { "Date:", "Location:", "Provider:", "Value:", "Other:" };
+			}
+			
+			@Override
+			public void setupRequest(MockHttpServletRequest request, Map<String, String> widgets) {
+				request.addParameter(widgets.get("Date:"), dateAsString(new Date()));
+				request.addParameter(widgets.get("Location:"), "2");
+				request.addParameter(widgets.get("Provider:"), "502");
+				request.addParameter(widgets.get("Other:"), "160");
+			}
+			
+			@Override
+			public void testResults(SubmissionResults results) {
+				results.assertNoErrors();
+				results.assertEncounterCreated();
+				results.assertObsGroupCreatedCount(0);
+			}
+		}.run();
+	}
+	
+	@Test
+	public void testObsGroupDeletesContextObsWhenCleared() throws Exception {
+		final Date date = new Date();
+		new RegressionTestHelper() {
+			
+			@Override
+			public String getFormName() {
+				return "obsGroupWithContextObs";
+			}
+			
+			@Override
+			public String[] widgetLabels() {
+				return new String[] { "Date:", "Location:", "Provider:", "Value:", "Other:" };
+			}
+			
+			@Override
+			public void setupRequest(MockHttpServletRequest request, Map<String, String> widgets) {
+				request.addParameter(widgets.get("Date:"), dateAsString(new Date()));
+				request.addParameter(widgets.get("Location:"), "2");
+				request.addParameter(widgets.get("Provider:"), "502");
+				request.addParameter(widgets.get("Value:"), "Bee stings");
+			}
+			
+			@Override
+			public boolean doEditEncounter() {
+				return true;
+			}
+			
+			@Override
+			public void testEditFormHtml(String html) {
+				String obsGroupHtml = html.split("obsgroup start")[1];
+				String[] tags = obsGroupHtml.split("<");
+				ArrayList<String> inputTags = new ArrayList<String>();
+				for (String tag : tags) {
+					if (tag.contains("input") && tag.contains("type=\"text\"")) {
+						inputTags.add(tag);
+					}
+				}
+				assertTrue("Should display only one input box within the obs group, found " + inputTags.size() + ": "
+				        + obsGroupHtml,
+				    inputTags.size() == 1);
+			}
+			
+			@Override
+			public void setupEditRequest(MockHttpServletRequest request, Map<String, String> widgets) {
+				request.setParameter(widgets.get("Value:"), "");
+				request.addParameter(widgets.get("Other:"), "170");
+			}
+			
+			@Override
+			public void testEditedResults(SubmissionResults results) {
+				results.assertNoErrors();
+				results.assertEncounterCreated();
+				results.assertObsGroupCreatedCount(0);
+				results.assertObsVoided(1000, conceptService.getConcept(1004));
+			}
+			
 		}.run();
 	}
 	

--- a/api/src/main/java/org/openmrs/module/htmlformentry/FormEntryContext.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/FormEntryContext.java
@@ -534,8 +534,8 @@ public class FormEntryContext {
 	
 	/**
 	 * Finds whether there is existing obs created for the question concept and numeric answer, returns
-	 * that <obs> if any, Use this only when datatype is numeric and style="checkbox" // TODO: that
-	 * can't be right
+	 * that <obs> if any, Use this only when datatype is numeric and style="checkbox"
+	 * // TODO: the above comment does not make sense
 	 *
 	 * @param question - the concept associated with the Obs to acquire
 	 * @param numericAns - numeric answer given with <obs/> declaration

--- a/api/src/main/java/org/openmrs/module/htmlformentry/FormEntryContext.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/FormEntryContext.java
@@ -534,7 +534,8 @@ public class FormEntryContext {
 	
 	/**
 	 * Finds whether there is existing obs created for the question concept and numeric answer, returns
-	 * that <obs> if any, Use this only when datatype is numeric and style="checkbox"
+	 * that <obs> if any, Use this only when datatype is numeric and style="checkbox" // TODO: that
+	 * can't be right
 	 *
 	 * @param question - the concept associated with the Obs to acquire
 	 * @param numericAns - numeric answer given with <obs/> declaration

--- a/api/src/main/java/org/openmrs/module/htmlformentry/FormEntryContext.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/FormEntryContext.java
@@ -535,7 +535,7 @@ public class FormEntryContext {
 	/**
 	 * Finds whether there is existing obs created for the question concept and numeric answer, returns
 	 * that <obs> if any, Use this only when datatype is numeric and style="checkbox"
-	 * // TODO: the above comment does not make sense
+	 * // TODO: the above comment does not make sense???
 	 *
 	 * @param question - the concept associated with the Obs to acquire
 	 * @param numericAns - numeric answer given with <obs/> declaration

--- a/api/src/main/java/org/openmrs/module/htmlformentry/FormSubmissionActions.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/FormSubmissionActions.java
@@ -226,6 +226,13 @@ public class FormSubmissionActions {
 	}
 	
 	/**
+	 * @return the ObsGroup that was most recently added to the stack
+	 */
+	public Obs getCurrentObsGroup() {
+		return highestOnStack(Obs.class);
+	}
+	
+	/**
 	 * Utility method that returns the object of a specified class that was most recently added to the
 	 * stack
 	 */

--- a/api/src/main/java/org/openmrs/module/htmlformentry/action/ObsGroupAction.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/action/ObsGroupAction.java
@@ -77,9 +77,17 @@ public class ObsGroupAction implements FormSubmissionControllerAction {
 				}
 			} else {
 				if (obsGroupSchemaObject.getContextObs() != null) {
-					// existingGroup seems never to exist. Not sure if something needs to be done to handle it.
+					// existingGroup seems never to exist. Not sure if something needs to be done to handle it,
+					// as is done in the other `if` branches.
 					Concept contextObsConcept = obsGroupSchemaObject.getContextObs().getKey();
 					Concept contextObsValue = obsGroupSchemaObject.getContextObs().getValue();
+					// If the obs group will have any members, we want to ensure that the context obs is present.
+					// Otherwise, we want to ensure that the context obs is absent.
+					// 
+					// To do this, we construct a list of the expected members which are not the context obs.
+					// This is the current members (which includes those to be added), minus those that will
+					// be voided, minus the context obs. In the process we find out whether the context obs
+					// already exists, which informs whether we need to create or void it.
 					ArrayList<Obs> members = new ArrayList<>();
 					Obs currentObsGroup = session.getSubmissionActions().getCurrentObsGroup();
 					if (currentObsGroup.getGroupMembers() != null) {

--- a/api/src/main/java/org/openmrs/module/htmlformentry/action/ObsGroupAction.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/action/ObsGroupAction.java
@@ -1,6 +1,7 @@
 package org.openmrs.module.htmlformentry.action;
 
 import javax.servlet.http.HttpServletRequest;
+import java.util.ArrayList;
 import java.util.Collection;
 
 import org.openmrs.Concept;
@@ -8,6 +9,7 @@ import org.openmrs.Obs;
 import org.openmrs.module.htmlformentry.FormEntryContext;
 import org.openmrs.module.htmlformentry.FormEntrySession;
 import org.openmrs.module.htmlformentry.FormSubmissionError;
+import org.openmrs.module.htmlformentry.HtmlFormEntryUtil;
 import org.openmrs.module.htmlformentry.InvalidActionException;
 import org.openmrs.module.htmlformentry.schema.ObsGroup;
 
@@ -32,8 +34,8 @@ public class ObsGroupAction implements FormSubmissionControllerAction {
 	 * 
 	 * @return
 	 */
-	public static ObsGroupAction end() {
-		return new ObsGroupAction(null, null, null, false);
+	public static ObsGroupAction end(ObsGroup ogSchemaObj) {
+		return new ObsGroupAction(null, null, ogSchemaObj, false);
 	}
 	
 	//------------------------------------
@@ -74,6 +76,31 @@ public class ObsGroupAction implements FormSubmissionControllerAction {
 					session.getSubmissionActions().beginObsGroup(obsGroup);
 				}
 			} else {
+				if (obsGroupSchemaObject.getContextObs() != null) {
+					// existingGroup seems never to exist. Not sure if something needs to be done to handle it.
+					Concept contextObsConcept = obsGroupSchemaObject.getContextObs().getKey();
+					Concept contextObsValue = obsGroupSchemaObject.getContextObs().getValue();
+					ArrayList<Obs> members = new ArrayList<>();
+					Obs currentObsGroup = session.getSubmissionActions().getCurrentObsGroup();
+					if (currentObsGroup.getGroupMembers() != null) {
+						members.addAll(currentObsGroup.getGroupMembers());
+					}
+					members.removeAll(session.getSubmissionActions().getObsToVoid());
+					Obs existingContextObs = null;
+					for (Obs member : members) {
+						if (member.getConcept() == contextObsConcept && member.getValueCoded() == contextObsValue) {
+							existingContextObs = member;
+							members.remove(existingContextObs);
+							break;
+						}
+					}
+					if (!members.isEmpty() && existingContextObs == null) {
+						session.getSubmissionActions().createObs(contextObsConcept, contextObsValue, null, null, null);
+					} else if (members.isEmpty() && existingContextObs != null) {
+						session.getSubmissionActions().modifyObs(existingContextObs, contextObsConcept, null, null, null,
+						    null);
+					}
+				}
 				session.getSubmissionActions().endObsGroup();
 			}
 		}

--- a/api/src/main/java/org/openmrs/module/htmlformentry/element/ObsSubmissionElement.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/element/ObsSubmissionElement.java
@@ -1382,7 +1382,7 @@ public class ObsSubmissionElement implements HtmlGeneratorElement, FormSubmissio
 		if (commentFieldWidget != null)
 			comment = commentFieldWidget.getValue(session.getContext(), submission);
 
-		// note that the rare use case where showCommentField=true and style=location won't work, as "org.openmrs.Location"
+		// note that style=location cannot be used with showCommentField=true, since "org.openmrs.Location"
 		// will override any user-entered comment
 		if (isLocationObs) {
 			comment = "org.openmrs.Location";
@@ -1403,12 +1403,13 @@ public class ObsSubmissionElement implements HtmlGeneratorElement, FormSubmissio
 
 			// call this regardless of whether the new value is null -- the
 			// modifyObs method is smart
-			if (concepts != null)
+			if (concepts != null) {
 				session.getSubmissionActions().modifyObs(existingObs, concept, answerConcept, obsDatetime,
 				    accessionNumberValue, comment);
-			else
+			} else {
 				session.getSubmissionActions().modifyObs(existingObs, concept, value, obsDatetime, accessionNumberValue,
-				    comment);
+					comment);
+			}
 		} else {
 			if (concepts != null && value != null && !"".equals(value) && concept != null) {
 				session.getSubmissionActions().createObs(concept, answerConcept, obsDatetime, accessionNumberValue, comment);

--- a/api/src/main/java/org/openmrs/module/htmlformentry/handler/ObsGroupTagHandler.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/handler/ObsGroupTagHandler.java
@@ -1,6 +1,7 @@
 package org.openmrs.module.htmlformentry.handler;
 
 import java.io.PrintWriter;
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -9,6 +10,7 @@ import java.util.Map;
 import org.openmrs.Concept;
 import org.openmrs.Obs;
 import org.openmrs.api.context.Context;
+import org.openmrs.module.htmlformentry.BadFormDesignException;
 import org.openmrs.module.htmlformentry.FormEntryContext.Mode;
 import org.openmrs.module.htmlformentry.FormEntrySession;
 import org.openmrs.module.htmlformentry.HtmlFormEntryUtil;
@@ -25,10 +27,13 @@ public class ObsGroupTagHandler extends AbstractTagHandler {
 	
 	boolean unmatchedInd = false;
 	
+	ObsGroup ogSchemaObj;
+	
 	@Override
 	protected List<AttributeDescriptor> createAttributeDescriptors() {
 		List<AttributeDescriptor> attributeDescriptors = new ArrayList<AttributeDescriptor>();
 		attributeDescriptors.add(new AttributeDescriptor("groupingConceptId", Concept.class));
+		attributeDescriptors.add(new AttributeDescriptor("contextObs", Concept.class));
 		return Collections.unmodifiableList(attributeDescriptors);
 	}
 	
@@ -37,17 +42,19 @@ public class ObsGroupTagHandler extends AbstractTagHandler {
 	 *      java.io.PrintWriter, org.w3c.dom.Node, org.w3c.dom.Node)
 	 */
 	@Override
-	public boolean doStartTag(FormEntrySession session, PrintWriter out, Node parent, Node node) {
+	public boolean doStartTag(FormEntrySession session, PrintWriter out, Node parent, Node node)
+	        throws BadFormDesignException {
 		
 		Map<String, String> attributes = getAttributes(node);
 		if (attributes.get("groupingConceptId") == null) {
-			throw new NullPointerException("obsgroup tag requires a groupingConceptId attribute");
+			throw new BadFormDesignException("obsgroup tag requires a groupingConceptId attribute");
 		}
 		Concept groupingConcept = HtmlFormEntryUtil.getConcept(attributes.get("groupingConceptId"));
 		if (groupingConcept == null) {
-			throw new NullPointerException("could not find concept " + attributes.get("groupingConceptId")
+			throw new BadFormDesignException("could not find concept " + attributes.get("groupingConceptId")
 			        + " as grouping obs for an obsgroup tag");
 		}
+		
 		boolean ignoreIfEmpty = session.getContext().getMode() == Mode.VIEW && "false".equals(attributes.get("showIfEmpty"));
 		
 		// avoid lazy init exception
@@ -84,7 +91,8 @@ public class ObsGroupTagHandler extends AbstractTagHandler {
 		}
 		
 		// sets up the obs group stack, sets current obs group to this one
-		ObsGroup ogSchemaObj = new ObsGroup(groupingConcept, name);
+		ogSchemaObj = new ObsGroup(groupingConcept, name);
+		ogSchemaObj.setContextObs(getContextObs(attributes.get("contextObs")));
 		session.getContext().beginObsGroup(groupingConcept, thisGroup, ogSchemaObj);
 		//adds the obsgroup action to the controller stack
 		session.getSubmissionController().addAction(ObsGroupAction.start(groupingConcept, thisGroup, ogSchemaObj));
@@ -104,6 +112,29 @@ public class ObsGroupTagHandler extends AbstractTagHandler {
 		
 	}
 	
+	private Map.Entry<Concept, Concept> getContextObs(String contextObsString) throws BadFormDesignException {
+		if (contextObsString != null) {
+			String[] contextObsStrings = contextObsString.split("=");
+			if (contextObsStrings.length != 2) {
+				throw new BadFormDesignException("obsgroup tag contextObs parameter requires exactly two concepts "
+				        + "delimited by an equals sign (=).");
+			}
+			Concept contextQuestion = HtmlFormEntryUtil.getConcept(contextObsStrings[0]);
+			if (contextQuestion == null) {
+				throw new BadFormDesignException("could not find concept " + contextObsStrings[0]
+				        + " as the question part of the contextObs for an obsgroup tag");
+			}
+			Concept contextValue = HtmlFormEntryUtil.getConcept(contextObsStrings[1]);
+			if (contextValue == null) {
+				throw new BadFormDesignException("could not find concept " + contextObsStrings[1]
+				        + " as the value part of the contextObs for an obsgroup tag");
+			}
+			return new AbstractMap.SimpleEntry<>(contextQuestion, contextValue);
+		} else {
+			return null;
+		}
+	}
+	
 	@Override
 	public void doEndTag(FormEntrySession session, PrintWriter out, Node parent, Node node) {
 		//                Concept question = null;
@@ -114,7 +145,7 @@ public class ObsGroupTagHandler extends AbstractTagHandler {
 		//                    } catch (Exception ex){}    
 		//                }
 		session.getContext().endObsGroup();
-		session.getSubmissionController().addAction(ObsGroupAction.end());
+		session.getSubmissionController().addAction(ObsGroupAction.end(ogSchemaObj));
 	}
 	
 	@Override

--- a/api/src/main/java/org/openmrs/module/htmlformentry/handler/ObsTagHandler.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/handler/ObsTagHandler.java
@@ -62,7 +62,7 @@ public class ObsTagHandler extends AbstractTagHandler {
 		ObsSubmissionElement element = (ObsSubmissionElement) popped;
 		if (session.getContext().getMode() != FormEntryContext.Mode.VIEW && element.hasWhenValueThen()) {
 			if (element.getId() == null) {
-				throw new IllegalStateException("<obs> must have an id attribute to define when-then actions");
+				throw new BadFormDesignException("<obs> must have an id attribute to define when-then actions");
 			}
 			out.println("<script type=\"text/javascript\">");
 			out.println("jQuery(function() { htmlForm.setupWhenThen('" + element.getId() + "', "

--- a/api/src/main/java/org/openmrs/module/htmlformentry/schema/ObsGroup.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/schema/ObsGroup.java
@@ -2,6 +2,7 @@ package org.openmrs.module.htmlformentry.schema;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.openmrs.Concept;
 
@@ -15,6 +16,8 @@ public class ObsGroup implements HtmlFormField {
 	private List<HtmlFormField> children = new ArrayList<HtmlFormField>();
 	
 	private String label;
+	
+	private Map.Entry<Concept, Concept> contextObs;
 	
 	public ObsGroup(Concept concept) {
 		this.concept = concept;
@@ -68,6 +71,14 @@ public class ObsGroup implements HtmlFormField {
 	
 	public void setLabel(String label) {
 		this.label = label;
+	}
+	
+	public Map.Entry<Concept, Concept> getContextObs() {
+		return contextObs;
+	}
+	
+	public void setContextObs(Map.Entry<Concept, Concept> contextObs) {
+		this.contextObs = contextObs;
 	}
 	
 }

--- a/api/src/test/java/org/openmrs/module/htmlformentry/RegressionTestHelper.java
+++ b/api/src/test/java/org/openmrs/module/htmlformentry/RegressionTestHelper.java
@@ -227,7 +227,7 @@ public abstract class RegressionTestHelper {
 	 * @see #widgetLabels()
 	 */
 	public String[] widgetLabelsForEdit() {
-		return new String[0];
+		return widgetLabels();
 	}
 	
 	/**
@@ -915,8 +915,8 @@ public abstract class RegressionTestHelper {
 		public void assertObsGroupCreated(int groupingConceptId, Object... conceptIdsAndValues) {
 			// quick checks
 			Assert.assertNotNull(encounterCreated);
-			Collection<Obs> temp = encounterCreated.getAllObs();
-			Assert.assertNotNull(temp);
+			Collection<Obs> createdObs = encounterCreated.getAllObs();
+			Assert.assertNotNull(createdObs);
 			
 			List<TestObsValue> expected = new ArrayList<TestObsValue>();
 			for (int i = 0; i < conceptIdsAndValues.length; i += 2) {
@@ -925,7 +925,7 @@ public abstract class RegressionTestHelper {
 				expected.add(new TestObsValue(conceptId, value));
 			}
 			
-			for (Obs o : temp) {
+			for (Obs o : createdObs) {
 				if (o.getConcept().getConceptId() == groupingConceptId) {
 					if (o.getValueCoded() != null || o.getValueComplex() != null || o.getValueDatetime() != null
 					        || o.getValueDrug() != null || o.getValueNumeric() != null || o.getValueText() != null) {

--- a/api/src/test/resources/org/openmrs/module/htmlformentry/include/obsGroupWithContextObs.xml
+++ b/api/src/test/resources/org/openmrs/module/htmlformentry/include/obsGroupWithContextObs.xml
@@ -1,0 +1,13 @@
+<htmlform>
+    Date: <encounterDate/>
+    Location: <encounterLocation/>
+    Provider: <encounterProvider role="Provider"/>
+    Other: <obs conceptId="5090"/>
+    <span>obsgroup start</span>
+    <obsgroup groupingConceptId="23" contextObs="1000=1004">
+        Value: <obs conceptId="80000"/>
+    </obsgroup>
+
+    <submit/>
+
+</htmlform>


### PR DESCRIPTION
https://issues.openmrs.org/browse/HTML-561

Using

```xml
<obsgroup groupingConceptId="CIEL:1727" contextObs="CIEL:1728=CIEL:151">
  <obs conceptId="CIEL:1729" answerConceptId="CIEL:1065" style="checkbox" answerLabel="Douleur abdominale"/>
</obsgroup>
```

We can achieve the following behavior:

![contextobs](https://user-images.githubusercontent.com/1031876/123708951-1b642380-d821-11eb-9ee7-3dd055a4997b.gif)
