### PR TITLE
HTML-790 - Allow mark a patient as deceased to be done conditionally

### DIFF
--- a/api-tests/src/test/java/org/openmrs/module/htmlformentry/handler/MarkPatientDeadTagHandlerComponentTest.java
+++ b/api-tests/src/test/java/org/openmrs/module/htmlformentry/handler/MarkPatientDeadTagHandlerComponentTest.java
@@ -53,4 +53,34 @@ public class MarkPatientDeadTagHandlerComponentTest extends BaseHtmlFormEntryTes
 		}.run();
 	}
 	
+	@Test
+	public void testMarkPatientDeadWithCheckbox() throws Exception {
+		final Date date = Date.from(LocalDate.now().atStartOfDay(ZoneId.systemDefault()).toInstant());
+		new RegressionTestHelper() {
+			
+			@Override
+			public String getFormName() {
+				return "markPatientDeadWithCheckbox";
+			}
+			
+			@Override
+			public String[] widgetLabels() {
+				return new String[] { "MarkPatientDead:", "Date:", "Location:", "Provider:", "Cause:" };
+			}
+			
+			@Override
+			public void setupRequest(MockHttpServletRequest request, Map<String, String> widgets) {
+				request.addParameter(widgets.get("Date:"), dateAsString(date));
+				request.addParameter(widgets.get("Location:"), "2");
+				request.addParameter(widgets.get("Provider:"), "502");
+				request.addParameter(widgets.get("Cause:"), "1001");
+				request.addParameter(widgets.get("MarkPatientDead:"), "false");
+			}
+			
+			@Override
+			public void testResults(SubmissionResults results) {
+				assertThat(results.getPatient().isDead(), is(false));
+			}
+		}.run();
+	}
 }

--- a/api-tests/src/test/java/org/openmrs/module/htmlformentry/handler/MarkPatientDeadTagHandlerTest.java
+++ b/api-tests/src/test/java/org/openmrs/module/htmlformentry/handler/MarkPatientDeadTagHandlerTest.java
@@ -20,6 +20,7 @@ import org.openmrs.Encounter;
 import org.openmrs.Obs;
 import org.openmrs.Patient;
 import org.openmrs.api.PatientService;
+import org.openmrs.module.htmlformentry.FormEntryContext;
 import org.openmrs.module.htmlformentry.FormEntrySession;
 import org.openmrs.module.htmlformentry.FormSubmissionController;
 import org.openmrs.module.htmlformentry.HtmlFormEntryUtil;
@@ -27,6 +28,7 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.springframework.mock.web.MockMultipartHttpServletRequest;
 
 @RunWith(PowerMockRunner.class)
 @PowerMockIgnore("javax.management.*")
@@ -95,6 +97,26 @@ public class MarkPatientDeadTagHandlerTest {
 	}
 	
 	@Test
+	public void testSetupWithShowCheckboxVisible() throws Exception {
+		Map<String, String> arguments = new HashMap<>();
+		arguments.put("showCheckbox", "true");
+		when(formEntrySession.getContext()).thenReturn(mock(FormEntryContext.class));
+		when(formEntrySession.getContext().getMode()).thenReturn(FormEntryContext.Mode.EDIT);
+		Assert.assertEquals(
+		    "<input type=\"checkbox\" id=\"null\" name=\"null\" value=\"true\"/><input type=\"hidden\" name=\"_null\"/>",
+		    tagHandler.getSubstitution(formEntrySession, submissionController, arguments));
+	}
+	
+	@Test
+	public void testSetupWithShowCheckboxNotVisible() throws Exception {
+		Map<String, String> arguments = new HashMap<>();
+		arguments.put("showCheckbox", "false");
+		when(formEntrySession.getContext()).thenReturn(mock(FormEntryContext.class));
+		when(formEntrySession.getContext().getMode()).thenReturn(FormEntryContext.Mode.EDIT);
+		Assert.assertEquals("", tagHandler.getSubstitution(formEntrySession, submissionController, arguments));
+	}
+	
+	@Test
 	public void testSetupWithCauseOfDeath() throws Exception {
 		Map<String, String> arguments = new HashMap<>();
 		arguments.put("causeOfDeathFromObs", "12345");
@@ -109,6 +131,7 @@ public class MarkPatientDeadTagHandlerTest {
 		MarkPatientDeadTagHandler.Action action = tagHandler.newAction();
 		action.setDeathDateFromEncounter(true);
 		
+		action.shouldPatientBeMarkedAsDeceased(formEntrySession, new MockMultipartHttpServletRequest());
 		action.applyAction(formEntrySession);
 		
 		Assert.assertEquals(true, patient.getDead());
@@ -126,6 +149,7 @@ public class MarkPatientDeadTagHandlerTest {
 		MarkPatientDeadTagHandler.Action action = tagHandler.newAction();
 		action.setDeathDateFromEncounter(true);
 		
+		action.shouldPatientBeMarkedAsDeceased(formEntrySession, new MockMultipartHttpServletRequest());
 		action.applyAction(formEntrySession);
 		
 		Assert.assertEquals(true, patient.getDead());
@@ -144,6 +168,7 @@ public class MarkPatientDeadTagHandlerTest {
 		action.setDeathDateFromEncounter(true);
 		action.setPreserveExistingDeathDate(true);
 		
+		action.shouldPatientBeMarkedAsDeceased(formEntrySession, new MockMultipartHttpServletRequest());
 		action.applyAction(formEntrySession);
 		
 		Assert.assertEquals(true, patient.getDead());
@@ -156,6 +181,7 @@ public class MarkPatientDeadTagHandlerTest {
 		MarkPatientDeadTagHandler.Action action = tagHandler.newAction();
 		action.setDeathDateFromEncounter(true);
 		
+		action.shouldPatientBeMarkedAsDeceased(formEntrySession, new MockMultipartHttpServletRequest());
 		action.applyAction(formEntrySession);
 		
 		Assert.assertEquals(true, patient.getDead());
@@ -167,6 +193,7 @@ public class MarkPatientDeadTagHandlerTest {
 	public void testNotSettingCauseOfDeath() {
 		MarkPatientDeadTagHandler.Action action = tagHandler.newAction();
 		
+		action.shouldPatientBeMarkedAsDeceased(formEntrySession, new MockMultipartHttpServletRequest());
 		action.applyAction(formEntrySession);
 		
 		Assert.assertEquals(true, patient.getDead());
@@ -186,6 +213,7 @@ public class MarkPatientDeadTagHandlerTest {
 		MarkPatientDeadTagHandler.Action action = tagHandler.newAction();
 		action.setCauseOfDeathFromObs(causeOfDeath);
 		
+		action.shouldPatientBeMarkedAsDeceased(formEntrySession, new MockMultipartHttpServletRequest());
 		action.applyAction(formEntrySession);
 		
 		Assert.assertEquals(true, patient.getDead());

--- a/api/src/test/resources/org/openmrs/module/htmlformentry/include/markPatientDeadWithCheckbox.xml
+++ b/api/src/test/resources/org/openmrs/module/htmlformentry/include/markPatientDeadWithCheckbox.xml
@@ -1,0 +1,11 @@
+<htmlform>
+    MarkPatientDead: <markPatientDead causeOfDeathFromObs="1000" showCheckbox="true"/>
+
+    Date: <encounterDate default="today" />
+    Location: <encounterLocation default="1"/>
+    Provider: <encounterProvider role="Provider" />
+
+    Cause: <obs conceptId="1000"/>
+
+    <submit/>
+</htmlform>


### PR DESCRIPTION
Ticket:
https://issues.openmrs.org/browse/HTML-790

What have I done:
Currently there is no way to opt in/out of <markPatientDead> withou removing it
So I added a new parameter named "showCheckbox".
- If "showCheckbox" is true, a check box will appear and if it is checked the patient will be mark  as deceased
- If "showCheckbox" is true, a check box will appear and if it is not checked the patient will not be marked as deceased
- If "showCheckbox" is false no checkbox will appear and the patient will be mark  as deceased

