### PR TITLE
Html 792

### DIFF
--- a/api-tests/src/test/java/org/openmrs/module/htmlformentry/element/OrderSubmissionElementTest.java
+++ b/api-tests/src/test/java/org/openmrs/module/htmlformentry/element/OrderSubmissionElementTest.java
@@ -133,7 +133,7 @@ public class OrderSubmissionElementTest extends BaseHtmlFormEntryTest {
 		triomuneField.orderAction("NEW").careSetting("2").urgency(Order.Urgency.ROUTINE.name());
 		triomuneField.freeTextDosing("Triomune instructions");
 		FormResultsTester results = formSessionTester.submitForm();
-		results.assertErrorMessage("htmlformentry.error.drugOrder.overlappingSchedule");
+		results.assertErrorMessage("htmlformentry.orders.overlappingScheduleForDrugOrder");
 	}
 	
 	@Test

--- a/api-tests/src/test/java/org/openmrs/module/htmlformentry/element/OrderSubmissionElementTest.java
+++ b/api-tests/src/test/java/org/openmrs/module/htmlformentry/element/OrderSubmissionElementTest.java
@@ -1,11 +1,5 @@
 package org.openmrs.module.htmlformentry.element;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
-
-import java.util.List;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.openmrs.DrugOrder;
@@ -17,6 +11,12 @@ import org.openmrs.module.htmlformentry.tester.FormResultsTester;
 import org.openmrs.module.htmlformentry.tester.FormSessionTester;
 import org.openmrs.module.htmlformentry.tester.FormTester;
 import org.openmrs.module.htmlformentry.tester.OrderFieldTester;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 public class OrderSubmissionElementTest extends BaseHtmlFormEntryTest {
 	
@@ -106,6 +106,34 @@ public class OrderSubmissionElementTest extends BaseHtmlFormEntryTest {
 		revisedTriomuneField.freeTextDosing("My instructions");
 		FormResultsTester revisedResults = formSessionTester.submitForm();
 		revisedResults.assertErrorMessage("htmlformentry.orders.dosingChangedForRenew");
+	}
+	
+	@Test
+	public void shouldFailValidationIfOverlappingOrders() {
+		FormTester formTester = FormTester.buildForm("orderTestForm.xml");
+		
+		// Enter an encounter with an order for drug 2
+		{
+			FormSessionTester formSessionTester = formTester.openNewForm(6);
+			formSessionTester.setEncounterFields("2020-03-30", "2", "502");
+			OrderFieldTester triomuneField = OrderFieldTester.forDrug(2, formSessionTester);
+			triomuneField.orderAction("NEW").careSetting("2").urgency(Order.Urgency.ROUTINE.name());
+			triomuneField.freeTextDosing("Triomune instructions");
+			FormResultsTester results = formSessionTester.submitForm();
+			results.assertNoErrors().assertEncounterCreated().assertOrderCreatedCount(1).assertNonVoidedOrderCount(1);
+			DrugOrder o1 = results.assertDrugOrder(Order.Action.NEW, 2);
+			TestUtil.assertDate(o1.getDateActivated(), "yyyy-MM-dd HH:mm:ss", "2020-03-30 00:00:00");
+			assertThat(o1.getDateStopped(), nullValue());
+		}
+		
+		// Now, enter an encounter a month later with another new order for drug 2.  This should fail validation
+		FormSessionTester formSessionTester = formTester.openNewForm(6);
+		formSessionTester.setEncounterFields("2020-04-30", "2", "502");
+		OrderFieldTester triomuneField = OrderFieldTester.forDrug(2, formSessionTester);
+		triomuneField.orderAction("NEW").careSetting("2").urgency(Order.Urgency.ROUTINE.name());
+		triomuneField.freeTextDosing("Triomune instructions");
+		FormResultsTester results = formSessionTester.submitForm();
+		results.assertErrorMessage("htmlformentry.error.drugOrder.overlappingSchedule");
 	}
 	
 	@Test

--- a/api/src/main/java/org/openmrs/module/htmlformentry/element/OrderSubmissionElement.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/element/OrderSubmissionElement.java
@@ -1,12 +1,5 @@
 package org.openmrs.module.htmlformentry.element;
 
-import javax.servlet.http.HttpServletRequest;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import org.apache.commons.lang.BooleanUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
@@ -32,6 +25,15 @@ import org.openmrs.module.htmlformentry.widget.OrderWidget;
 import org.openmrs.module.htmlformentry.widget.OrderWidgetConfig;
 import org.openmrs.module.htmlformentry.widget.OrderWidgetValue;
 import org.openmrs.util.OpenmrsUtil;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Holds the widgets used to represent orders for a configured set of orderables (concepts, drugs),
@@ -165,6 +167,8 @@ public class OrderSubmissionElement implements HtmlGeneratorElement, FormSubmiss
 						if (newDrugOrder.getQuantity() != null) {
 							handleRequiredField(ret, ctx, fs, "quantityUnits", newDrugOrder.getQuantityUnits());
 						}
+						
+						validateNoOverlappingDrugOrders(ret, ctx, fs, "drug", newDrugOrder);
 					}
 				}
 				
@@ -300,6 +304,70 @@ public class OrderSubmissionElement implements HtmlGeneratorElement, FormSubmiss
 			String field = orderWidget.getFormErrorField(ctx, fieldSuffix, prop);
 			addError(ret, field, "htmlformentry.error.required");
 		}
+	}
+	
+	/**
+	 * Validate that the given DrugOrder does not overlap with other DrugOrders. The below logic is
+	 * essentially copied out of OrderServiceImpl in the 2.3.x branch It does not support the ability to
+	 * allow for parallel orders via the OrderContext
+	 * 
+	 * @param order
+	 */
+	public void validateNoOverlappingDrugOrders(List<FormSubmissionError> ret, FormEntryContext ctx, String fieldSuffix,
+	        String prop, DrugOrder order) {
+		Set<Concept> orderConcepts = new HashSet<>();
+		orderConcepts.add(order.getConcept());
+		// Concepts Match
+		for (Order orderToCheck : HtmlFormEntryUtil.getOrdersForPatient(ctx.getExistingPatient(), orderConcepts)) {
+			// Care Settings Match
+			if (OpenmrsUtil.nullSafeEquals(order.getCareSetting(), orderToCheck.getCareSetting())) {
+				// Orderables Match
+				if (order.hasSameOrderableAs(orderToCheck)) {
+					// Not the same order
+					if (!order.equals(orderToCheck)) {
+						// Not a revision of the order to check
+						if (order.getPreviousOrder() == null || !order.getPreviousOrder().equals(orderToCheck)) {
+							// Has an overlapping schedule
+							if (checkScheduleOverlap(order, orderToCheck)) {
+								String field = orderWidget.getFormErrorField(ctx, fieldSuffix, prop);
+								addError(ret, field, "htmlformentry.error.drugOrder.overlappingSchedule");
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	
+	private boolean checkScheduleOverlap(Order newOrder, Order existingOrder) {
+		Date newStart = newOrder.getEffectiveStartDate() == null ? new Date() : newOrder.getEffectiveStartDate();
+		Date newStop = newOrder.getEffectiveStopDate();
+		Date existingStart = existingOrder.getEffectiveStartDate();
+		Date existingStop = existingOrder.getEffectiveStopDate();
+		
+		// If both orders start on the same date, then they overlap
+		if (OpenmrsUtil.compareWithNullAsLatest(newStart, existingStart) == 0) {
+			return true;
+		}
+		
+		// If both orders end on the same date, or if they are both open-ended, then they overlap
+		if (OpenmrsUtil.compareWithNullAsLatest(newStop, existingStop) == 0) {
+			return true;
+		}
+		
+		// If the new order starts before the existing order, it must end before the existing order starts
+		if (OpenmrsUtil.compareWithNullAsLatest(newStart, existingStart) < 0
+		        && OpenmrsUtil.compareWithNullAsLatest(newStop, existingStart) >= 0) {
+			return true;
+		}
+		
+		// If the new order starts after the existing order, it must start after the existing order ends
+		if (OpenmrsUtil.compareWithNullAsLatest(newStart, existingStart) > 0
+		        && OpenmrsUtil.compareWithNullAsLatest(newStop, existingStop) <= 0) {
+			return true;
+		}
+		
+		return false;
 	}
 	
 	public void addError(List<FormSubmissionError> ret, String field, String messageCode) {

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -140,6 +140,7 @@ htmlformentry.orders.drugChangedForRevision      = No drug changes are permitted
 htmlformentry.orders.dosingChangedForRenew       = No dosing changes are permitted when issuing a renew order
 htmlformentry.orders.invalidDosingType                = Please chose a valid dosing type
 htmlformentry.orders.specifyEitherDrugOrDrugNonCoded  = You cannot specify both a coded and non-coded drug formulation
+htmlformentry.orders.overlappingScheduleForDrugOrder = You cannot order a drug that is already active for this patient
 
 htmlformentry.warning.invalidMember                      = Warning! obs concept ({0}) does not belong to the {1} obs group set
 htmlformentry.warning.groupingConcept                    = Warning! obs group ({0}) is not a set

--- a/omod/src/main/webapp/resources/orderWidget.js
+++ b/omod/src/main/webapp/resources/orderWidget.js
@@ -618,9 +618,11 @@
         if (data.values && data.values.length > 0) {
             data.values.forEach(function (val) {
                 var config = data.config;
-                var fieldSuffix = val.fieldSuffix;
-                var action = val.action;
-                var $actionButton = $('#order-action-button-' + action + fieldSuffix);
+                var actionButtonId = val.action;
+                if (actionButtonId !== 'NEW') {
+                    actionButtonId += val.fieldSuffix;
+                }
+                var $actionButton = $('#order-action-button-' + actionButtonId);
                 $actionButton.click();
                 val.fields.forEach(function (field) {
                     setValueByName(field.name, field.value);


### PR DESCRIPTION
Addresses the following 2 issues:

1. Adds a validation to the OrderSubmissionElement that mimics the validation from the OrderService having to do with overlapping orders for the same orderable, and if an order is submitted that will fail back-end validation due to this, a new htmlform field validation error is displayed.

2. Fixes a bug with displaying validation issues for new orders in the order tag on an htmlform, which was introduced when the handling for new orders was adjusted to choose the orderable after choosing to place a new order.