### PR TITLE
HTML-798 Add "allowPastDates" attribute to Obs tag

### DIFF
--- a/api/src/main/java/org/openmrs/module/htmlformentry/element/ObsSubmissionElement.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/element/ObsSubmissionElement.java
@@ -110,6 +110,8 @@ public class ObsSubmissionElement implements HtmlGeneratorElement, FormSubmissio
 	
 	private boolean allowFutureDates = false;
 	
+	private boolean allowPastDates = true;
+	
 	private Concept answerConcept;
 	
 	private Drug answerDrug;
@@ -213,6 +215,9 @@ public class ObsSubmissionElement implements HtmlGeneratorElement, FormSubmissio
 		
 		if ("true".equalsIgnoreCase(parameters.get("allowFutureDates"))) {
 			allowFutureDates = true;
+		}
+		if ("false".equalsIgnoreCase(parameters.get("allowPastDates"))) {
+			allowPastDates = false;
 		}
 		if ("true".equalsIgnoreCase(parameters.get("required"))) {
 			required = true;
@@ -985,6 +990,9 @@ public class ObsSubmissionElement implements HtmlGeneratorElement, FormSubmissio
 					if (!allowFutureDates) {
 						((DateWidget) valueWidget).setMaxDate(getMaxDateForDateWidget(context, existingObs));
 					}
+					if (!allowPastDates) {
+						((DateWidget) valueWidget).setMinDate(getMinDateForDateWidget(context, existingObs));
+					}
 				} else if (ConceptDatatype.TIME.equals(concept.getDatatype().getHl7Abbreviation())) {
 					valueWidget = new TimeWidget();
 					if (hideSeconds) {
@@ -994,6 +1002,9 @@ public class ObsSubmissionElement implements HtmlGeneratorElement, FormSubmissio
 					dateWidget = new DateWidget();
 					if (!allowFutureDates) {
 						dateWidget.setMaxDate(getMaxDateForDateWidget(context, existingObs));
+					}
+					if (!allowPastDates) {
+						dateWidget.setMinDate(getMinDateForDateWidget(context, existingObs));
 					}
 					timeWidget = new TimeWidget();
 					if (hideSeconds) {
@@ -1336,13 +1347,24 @@ public class ObsSubmissionElement implements HtmlGeneratorElement, FormSubmissio
 			        Context.getMessageSourceService().getMessage("htmlformentry.error.cannotBeInFuture")));
 		}
 		
-		if (value instanceof Date && !allowFutureDates) {
-			// make sure obs date is not before the current encounter date
-			Date encounterDateToTest = getBestApproximationOfEncounterDate(context);
-			
-			if (encounterDateToTest != null && OpenmrsUtil.compare((Date) value, encounterDateToTest) > 0) {
-				ret.add(new FormSubmissionError(valueWidget,
-				        Context.getMessageSourceService().getMessage("htmlformentry.error.cannotBeAfterEncounterDate")));
+		if (value instanceof Date) {
+			if (!allowFutureDates) {
+				// make sure obs date is not before the current encounter date
+				Date encounterDateToTest = getBestApproximationOfEncounterDate(context);
+				
+				if (encounterDateToTest != null && OpenmrsUtil.compare((Date) value, encounterDateToTest) > 0) {
+					ret.add(new FormSubmissionError(valueWidget,
+					        Context.getMessageSourceService().getMessage("htmlformentry.error.cannotBeAfterEncounterDate")));
+				}
+			}
+			if (!allowPastDates) {
+				// make sure obs date is not before the current encounter date
+				Date encounterDateToTest = getBestApproximationOfEncounterDate(context);
+				
+				if (encounterDateToTest != null && OpenmrsUtil.compare((Date) value, encounterDateToTest) < 0) {
+					ret.add(new FormSubmissionError(valueWidget, Context.getMessageSourceService()
+					        .getMessage("htmlformentry.error.cannotBeBeforeEncounterDate")));
+				}
 			}
 		}
 		
@@ -1514,11 +1536,29 @@ public class ObsSubmissionElement implements HtmlGeneratorElement, FormSubmissio
 		// if the existing obs value is outside the allowable range (ie after encounter date), which
 		// could be possible if the encounter date was somehow updated after obs value date was entered,
 		// increase the max value so that the widget won't inadvertently change the value;
-		// server-side validation will still catch the validaton error
+		// server-side validation will still catch the validation error
 		if (existingObs != null && existingObs.getValueDate() != null && existingObs.getValueDate().after(encounterDate)) {
 			return existingObs.getValueDate();
 		} else if (existingObs != null && existingObs.getValueDatetime() != null
 		        && existingObs.getValueDatetime().after(encounterDate)) {
+			return existingObs.getValueDatetime();
+		} else {
+			return encounterDate;
+		}
+		
+	}
+	
+	private Date getMinDateForDateWidget(FormEntryContext context, Obs existingObs) {
+		Date encounterDate = getBestApproximationOfEncounterDate(context);
+		
+		// if the existing obs value is outside the allowable range (ie before encounter date), which
+		// could be possible if the encounter date was somehow updated after obs value date was entered,
+		// decrease the min value so that the widget won't inadvertently change the value;
+		// server-side validation will still catch the validation error
+		if (existingObs != null && existingObs.getValueDate() != null && existingObs.getValueDate().before(encounterDate)) {
+			return existingObs.getValueDate();
+		} else if (existingObs != null && existingObs.getValueDatetime() != null
+		        && existingObs.getValueDatetime().before(encounterDate)) {
 			return existingObs.getValueDatetime();
 		} else {
 			return encounterDate;

--- a/api/src/main/java/org/openmrs/module/htmlformentry/widget/DateWidget.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/widget/DateWidget.java
@@ -30,6 +30,8 @@ public class DateWidget implements Widget {
 	
 	private Date maxDate;
 	
+	private Date minDate;
+	
 	private boolean hidden = false;
 	
 	public DateWidget() {
@@ -194,6 +196,14 @@ public class DateWidget implements Widget {
 		this.maxDate = maxDate;
 	}
 	
+	public Date getMinDate() {
+		return minDate;
+	}
+	
+	public void setMinDate(Date minDate) {
+		this.minDate = minDate;
+	}
+	
 	public DateWidget clone() {
 		DateWidget clone = new DateWidget();
 		clone.setInitialValue(this.getInitialValue());
@@ -201,6 +211,7 @@ public class DateWidget implements Widget {
 		clone.setHidden(this.isHidden());
 		clone.setDateFormat(this.getDateFormat());
 		clone.setMaxDate(this.getMaxDate());
+		clone.setMinDate(this.getMinDate());
 		return clone;
 	}
 }

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -16,6 +16,7 @@ htmlformentry.error.autoCompleteOptionNotValid           = Please select a valid
 htmlformentry.error.blockMultipleEncounterOnDate         = This form has already been entered for the patient on the date you have chosen.  If you have entered the wrong date, please enter the correct one.  If you have entered the correct date, please find the encounter that has already been entered.
 htmlformentry.error.cannotBeInFuture                     = Cannot be in the future
 htmlformentry.error.cannotBeAfterEncounterDate           = Cannot be after encounter date
+htmlformentry.error.cannotBeBeforeEncounterDate          = Cannot be before encounter date
 htmlformentry.error.cannotChooseADrugHeader              = Oops!  You selected a drug header instead of a specific drug.  
 htmlformentry.error.changedEncounterDate                 = Changing encounter date is not supported with workflow state
 htmlformentry.error.dateWithoutValue                     = Date without value

--- a/api/src/test/resources/org/openmrs/module/htmlformentry/include/singleObsFormWithDateAndAllowPastDatesFalse.xml
+++ b/api/src/test/resources/org/openmrs/module/htmlformentry/include/singleObsFormWithDateAndAllowPastDatesFalse.xml
@@ -1,0 +1,7 @@
+<htmlform>
+    Date: <encounterDate/>
+    Location: <encounterLocation/>
+    Provider: <encounterProvider role="Provider"/>
+    Obs date: <obs conceptId="1119" allowPastDates="false"/>
+    <submit/>
+</htmlform>


### PR DESCRIPTION
Adds a new option attribute to the obs tag for date obs that enables one to specify that past dates should be disallowed and lead to validation errors.  Note:  this is only enabled as server-side validation due to complexities in adjusting to the effective validation date when the encounter date field on the form changes.  If client-side validation is desired, that can be tackled in a separate ticket.
