### PR TITLE
HTML-836 - Drugs should be sorted alphabetically if an explicit order is not set

### DIFF
--- a/api/src/main/java/org/openmrs/module/htmlformentry/handler/OrderTagHandler.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/handler/OrderTagHandler.java
@@ -611,6 +611,9 @@ public class OrderTagHandler extends AbstractTagHandler {
 		if (!conceptsExplicitlyDefined) {
 			concepts.sort(Comparator.comparing(option -> option.getLabel().toLowerCase()));
 		}
+		if (!drugsExplicitlyDefined) {
+			drugs.sort(Comparator.comparing(option -> option.getLabel().toLowerCase()));
+		}
 	}
 	
 	protected List<Concept> getConceptsForOptionGroup(ConceptOptionGroup optionGroup) {


### PR DESCRIPTION
## Issue I worked on
see https://issues.openmrs.org/browse/HTML-836