### PR TITLE
HTML-885: Add a way to input provider obs with autocomplete search

### DIFF
--- a/api-tests/src/test/java/org/openmrs/module/htmlformentry/HtmlFormEntryUtilTest.java
+++ b/api-tests/src/test/java/org/openmrs/module/htmlformentry/HtmlFormEntryUtilTest.java
@@ -1115,6 +1115,21 @@ public class HtmlFormEntryUtilTest extends BaseHtmlFormEntryTest {
 	}
 	
 	@Test
+	@Verifies(value = "shouldSetValueTextToProviderIdGivenAProvider", method = "createObs(Concept concept, Object value, Date datetime, String accessionNumber)")
+	public void createObs_shouldSetValueTextToProviderIdGivenAProvider() {
+		Provider provider = new Provider();
+		provider.setId(42);
+
+		Concept c = new Concept();
+		ConceptDatatype cd = new ConceptDatatype();
+		cd.setUuid("8d4a4ab4-c2cc-11de-8d13-0010c6dffd0f");
+		c.setDatatype(cd);
+
+		Obs o = HtmlFormEntryUtil.createObs(c, provider, null, null);
+		Assert.assertEquals("42", o.getValueText());
+	}
+
+	@Test
 	@Verifies(value = "shouldSetTheValueComplexOfObsIfConceptIsComplex", method = "createObs(Concept concept, Object value, Date datetime, String accessionNumber)")
 	public void createObs_shouldSetTheValueComplexOfObsIfConceptIsComplex() {
 		

--- a/api-tests/src/test/java/org/openmrs/module/htmlformentry/element/ObsSubmissionElementTest.java
+++ b/api-tests/src/test/java/org/openmrs/module/htmlformentry/element/ObsSubmissionElementTest.java
@@ -37,6 +37,7 @@ import org.openmrs.ConceptName;
 import org.openmrs.ConceptNumeric;
 import org.openmrs.api.ConceptNameType;
 import org.openmrs.api.context.Context;
+import org.openmrs.module.htmlformentry.BadFormDesignException;
 import org.openmrs.module.htmlformentry.FormEntryContext;
 import org.openmrs.module.htmlformentry.HtmlFormEntryUtil;
 import org.openmrs.module.htmlformentry.TestUtil;
@@ -84,7 +85,7 @@ public class ObsSubmissionElementTest {
 	}
 	
 	@Test
-	public void testShowUnitsUsingTrue() {
+	public void testShowUnitsUsingTrue() throws Exception {
 		ConceptDatatype numeric = new ConceptDatatype();
 		numeric.setUuid(ConceptDatatype.NUMERIC_UUID);
 		
@@ -106,7 +107,7 @@ public class ObsSubmissionElementTest {
 	
 	@Test
 	@Ignore
-	public void testShowUnitsUsingCode() {
+	public void testShowUnitsUsingCode() throws Exception {
 		ConceptDatatype numeric = new ConceptDatatype();
 		numeric.setUuid(ConceptDatatype.NUMERIC_UUID);
 		
@@ -211,31 +212,31 @@ public class ObsSubmissionElementTest {
 	}
 	
 	@Test(expected = RuntimeException.class)
-	public void testNoConceptId_shouldThrowException() {
+	public void testNoConceptId_shouldThrowException() throws Exception {
 		new ObsSubmissionElement(context, params);
 	}
 	
 	@Test(expected = RuntimeException.class)
-	public void testDuplicateConceptIds_shouldThrowException() {
+	public void testDuplicateConceptIds_shouldThrowException() throws Exception {
 		params.put("conceptId", "1");
 		params.put("conceptIds", "2");
 		new ObsSubmissionElement(context, params);
 	}
 	
 	@Test(expected = RuntimeException.class)
-	public void testInvalidConceptIds_shouldThrowException() {
+	public void testInvalidConceptIds_shouldThrowException() throws Exception{
 		params.put("conceptIds", "adas,asda");
 		new ObsSubmissionElement(context, params);
 	}
 	
 	@Test(expected = RuntimeException.class)
-	public void testEmptyConceptIds_shouldThrowException() {
+	public void testEmptyConceptIds_shouldThrowException() throws Exception {
 		params.put("conceptIds", "");
 		new ObsSubmissionElement(context, params);
 	}
 	
 	@Test(expected = RuntimeException.class)
-	public void testInvalidAnswerConceptIds_shouldThrowException() {
+	public void testInvalidAnswerConceptIds_shouldThrowException() throws Exception {
 		params.put("answerConceptIds", "adas,asda");
 		new ObsSubmissionElement(context, params);
 	}

--- a/api/src/main/java/org/openmrs/module/htmlformentry/HtmlFormEntryUtil.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/HtmlFormEntryUtil.java
@@ -282,6 +282,8 @@ public class HtmlFormEntryUtil {
 			} else if (value instanceof Person) {
 				Person person = (Person) value;
 				obs.setValueText(person.getId().toString() + " - " + person.getPersonName().toString());
+			} else if (value instanceof Provider) {
+				obs.setValueText(((Provider) value).getId().toString());
 			} else {
 				obs.setValueText(value.toString());
 			}

--- a/api/src/main/java/org/openmrs/module/htmlformentry/element/ObsReferenceSubmissionElement.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/element/ObsReferenceSubmissionElement.java
@@ -12,6 +12,7 @@ import org.openmrs.Concept;
 import org.openmrs.Obs;
 import org.openmrs.Person;
 import org.openmrs.api.context.Context;
+import org.openmrs.module.htmlformentry.BadFormDesignException;
 import org.openmrs.module.htmlformentry.FormEntryContext;
 import org.openmrs.module.htmlformentry.HtmlFormEntryConstants;
 import org.openmrs.module.htmlformentry.HtmlFormEntryUtil;
@@ -37,7 +38,7 @@ public class ObsReferenceSubmissionElement extends ObsSubmissionElement<FormEntr
 	
 	private String tooltipTemplate = "({{encounterType}} on {{encounterDate}})";
 	
-	public ObsReferenceSubmissionElement(FormEntryContext context, Map<String, String> parameters) {
+	public ObsReferenceSubmissionElement(FormEntryContext context, Map<String, String> parameters) throws BadFormDesignException {
 		
 		super(context, parameters);
 		

--- a/api/src/main/java/org/openmrs/module/htmlformentry/element/ObsSubmissionElement.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/element/ObsSubmissionElement.java
@@ -30,8 +30,10 @@ import org.openmrs.module.htmlformentry.widget.CheckboxWidget;
 import org.openmrs.module.htmlformentry.widget.ConceptSearchAutocompleteWidget;
 import org.openmrs.module.htmlformentry.widget.DateTimeWidget;
 import org.openmrs.module.htmlformentry.widget.DateWidget;
+import org.openmrs.module.htmlformentry.util.MatchMode;
 import org.openmrs.module.htmlformentry.widget.DropdownWidget;
 import org.openmrs.module.htmlformentry.widget.DynamicAutocompleteWidget;
+import org.openmrs.module.htmlformentry.widget.ProviderAjaxAutoCompleteWidget;
 import org.openmrs.module.htmlformentry.widget.ErrorWidget;
 import org.openmrs.module.htmlformentry.widget.NumberFieldWidget;
 import org.openmrs.module.htmlformentry.widget.Option;
@@ -241,7 +243,7 @@ public class ObsSubmissionElement<T extends FormEntryContext> implements HtmlGen
 		isLocationObs = "location".equals(parameters.get("style")) || "location_radio".equals(parameters.get("style"))
 		        || "location_dropdown".equals(parameters.get("style"));
 		isProviderObs = "provider".equals(parameters.get("style")) || "provider_radio".equals(parameters.get("style"))
-		        || "provider_dropdown".equals(parameters.get("style"));
+		        || "provider_dropdown".equals(parameters.get("style")) || "provider_autocomplete".equals(parameters.get("style"));
 		isRadioSet = "radio".equals(parameters.get("style")) || "location_radio".equals(parameters.get("style"))
 		        || "provider_radio".equals(parameters.get("style"));
 		
@@ -565,19 +567,6 @@ public class ObsSubmissionElement<T extends FormEntryContext> implements HtmlGen
 				}
 				// configure the special obs type that allows selection of a provider (the provider_id PK is stored as the valueText)
 				else if (isProviderObs) {
-					if (isRadioSet) {
-						valueWidget = new RadioButtonsWidget();
-						if (answerSeparator != null) {
-							((RadioButtonsWidget) valueWidget).setAnswerSeparator(answerSeparator);
-						}
-					} else { // dropdown
-						valueWidget = new DropdownWidget();
-						// if initialValueIsSet=false, no initial/default location, hence this shows the 'select input' field as first option
-						boolean initialValueIsSet = !(initialValue == null);
-						((SingleOptionWidget) valueWidget).addOption(
-						    new Option(Context.getMessageSourceService().getMessage("htmlformentry.chooseAProvider"), "",
-						            !initialValueIsSet));
-					}
 					List<String> roleIds = new ArrayList<>();
 					String roleParam = parameters.get("providerRoles");
 					if (StringUtils.isNotBlank(roleParam)) {
@@ -585,20 +574,48 @@ public class ObsSubmissionElement<T extends FormEntryContext> implements HtmlGen
 							roleIds.add(roleId.trim());
 						}
 					}
-					List<Provider> providers = HtmlFormEntryUtil.getProviders(roleIds, true);
-					
-					List<Option> providerOptions = new ArrayList<>();
-					for (Provider provider : providers) {
-						String providerId = provider.getId().toString();
-						String label = HtmlFormEntryUtil.format(provider);
-						Option option = new Option(label, providerId, providerId.equals(initialValue));
-						providerOptions.add(option);
-					}
-					Collections.sort(providerOptions, new OptionComparator());
-					
-					if (!providerOptions.isEmpty()) {
-						for (Option option : providerOptions) {
-							((SingleOptionWidget) valueWidget).addOption(option);
+					if ("provider_autocomplete".equals(parameters.get("style"))) {
+						MatchMode matchMode = MatchMode.ANYWHERE;
+						if (StringUtils.isNotBlank(parameters.get("providerMatchMode"))) {
+							try {
+								matchMode = MatchMode.valueOf(parameters.get("providerMatchMode").toUpperCase());
+							}
+							catch (IllegalArgumentException e) {
+								throw new IllegalArgumentException(
+									"Invalid providerMatchMode '" + parameters.get("providerMatchMode")
+									+ "'. Valid values are: " + Arrays.toString(MatchMode.values()));
+							}
+						}
+						valueWidget = new ProviderAjaxAutoCompleteWidget(matchMode, roleIds);
+					} else {
+						if (isRadioSet) {
+							valueWidget = new RadioButtonsWidget();
+							if (answerSeparator != null) {
+								((RadioButtonsWidget) valueWidget).setAnswerSeparator(answerSeparator);
+							}
+						} else { // dropdown
+							valueWidget = new DropdownWidget();
+							// if initialValueIsSet=false, no initial/default location, hence this shows the 'select input' field as first option
+							boolean initialValueIsSet = !(initialValue == null);
+							((SingleOptionWidget) valueWidget).addOption(
+								new Option(Context.getMessageSourceService().getMessage("htmlformentry.chooseAProvider"), "",
+									!initialValueIsSet));
+						}
+						List<Provider> providers = HtmlFormEntryUtil.getProviders(roleIds, true);
+
+						List<Option> providerOptions = new ArrayList<>();
+						for (Provider provider : providers) {
+							String providerId = provider.getId().toString();
+							String label = HtmlFormEntryUtil.format(provider);
+							Option option = new Option(label, providerId, providerId.equals(initialValue));
+							providerOptions.add(option);
+						}
+						Collections.sort(providerOptions, new OptionComparator());
+
+						if (!providerOptions.isEmpty()) {
+							for (Option option : providerOptions) {
+								((SingleOptionWidget) valueWidget).addOption(option);
+							}
 						}
 					}
 				} else if ("person".equals(parameters.get("style"))) {

--- a/api/src/main/java/org/openmrs/module/htmlformentry/element/ObsSubmissionElement.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/element/ObsSubmissionElement.java
@@ -15,6 +15,7 @@ import org.openmrs.Provider;
 import org.openmrs.Role;
 import org.openmrs.Visit;
 import org.openmrs.api.context.Context;
+import org.openmrs.module.htmlformentry.BadFormDesignException;
 import org.openmrs.module.htmlformentry.FormEntryContext;
 import org.openmrs.module.htmlformentry.FormEntryContext.Mode;
 import org.openmrs.module.htmlformentry.FormEntrySession;
@@ -165,7 +166,7 @@ public class ObsSubmissionElement<T extends FormEntryContext> implements HtmlGen
 	
 	private String tagControlId;
 	
-	public ObsSubmissionElement(T context, Map<String, String> parameters) {
+	public ObsSubmissionElement(T context, Map<String, String> parameters) throws BadFormDesignException {
 		if (parameters.get("locale") != null) {
 			this.locale = LocaleUtility.fromSpecification(parameters.get("locale"));
 		}
@@ -275,7 +276,7 @@ public class ObsSubmissionElement<T extends FormEntryContext> implements HtmlGen
 		return dropdownWidget;
 	}
 	
-	private void prepareWidgets(T context, Map<String, String> parameters) {
+	private void prepareWidgets(T context, Map<String, String> parameters) throws BadFormDesignException {
 		String userLocaleStr = locale.toString();
 		try {
 			if (answerConcept == null)
@@ -580,10 +581,10 @@ public class ObsSubmissionElement<T extends FormEntryContext> implements HtmlGen
 							try {
 								matchMode = MatchMode.valueOf(parameters.get("providerMatchMode").toUpperCase());
 							}
-							catch (IllegalArgumentException e) {
-								throw new IllegalArgumentException(
+							catch (Exception e) {
+								throw new BadFormDesignException(
 									"Invalid providerMatchMode '" + parameters.get("providerMatchMode")
-									+ "'. Valid values are: " + Arrays.toString(MatchMode.values()));
+									+ "'. Valid values are: " + Arrays.toString(MatchMode.values()), e);
 							}
 						}
 						valueWidget = new ProviderAjaxAutoCompleteWidget(matchMode, roleIds);

--- a/omod/src/main/java/org/openmrs/module/htmlformentry/web/controller/ProviderSearchController.java
+++ b/omod/src/main/java/org/openmrs/module/htmlformentry/web/controller/ProviderSearchController.java
@@ -33,6 +33,10 @@ public class ProviderSearchController {
 		
 		List<Provider> providerList = HtmlFormEntryUtil.getProviders(providerRoleIds, true);
 		
+		if (matchMode == null) {
+			matchMode = MatchMode.ANYWHERE;
+		}
+
 		List<ProviderStub> stubs;
 		if (searchParam == null) {
 			stubs = HtmlFormEntryUtil.getProviderStubs(providerList);

--- a/omod/src/main/java/org/openmrs/module/htmlformentry/web/controller/ProviderSearchController.java
+++ b/omod/src/main/java/org/openmrs/module/htmlformentry/web/controller/ProviderSearchController.java
@@ -33,6 +33,10 @@ public class ProviderSearchController {
 		
 		List<Provider> providerList = HtmlFormEntryUtil.getProviders(providerRoleIds, true);
 		
+		/*
+		 * A frontend bug makes it possible for the matchMode to be null, when the element is considered rendered with <controls>;
+		 * see HTML-887. In that case, we default to MatchMode.ANYWHERE.
+		 */
 		if (matchMode == null) {
 			matchMode = MatchMode.ANYWHERE;
 		}


### PR DESCRIPTION
See: https://openmrs.atlassian.net/browse/HTML-885

The `ProviderAjaxAutoCompleteWidget` is already created, but only used for the `<EncounterProviderAndRole>` tag. This PR adds function to input provider as obs with an autocomplete search.