### PR TITLE
HTML-893: Obs checkbox element should only show dateLabel when checked

### DIFF
--- a/api/src/main/java/org/openmrs/module/htmlformentry/element/ObsSubmissionElement.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry/element/ObsSubmissionElement.java
@@ -1282,11 +1282,31 @@ public class ObsSubmissionElement<T extends FormEntryContext> implements HtmlGen
 			ret.append("</span>");
 		}
 		if (dateWidget != null) {
+			// For a checkbox-style obs, the date (label + widget + clear button) is only meaningful once the
+			// checkbox is checked, so wrap it and toggle its visibility off the checkbox state.
+			boolean toggleDateWithCheckbox = context.getMode() != Mode.VIEW && valueWidget instanceof CheckboxWidget;
+			String dateHolderId = null;
+			if (toggleDateWithCheckbox) {
+				CheckboxWidget checkbox = (CheckboxWidget) valueWidget;
+				boolean checked = checkbox.getInitialValue() != null && !"".equals(checkbox.getInitialValue());
+				dateHolderId = context.getFieldNameIfRegistered(valueWidget) + "_date_holder";
+				ret.append("<span id=\"").append(dateHolderId).append("\"");
+				if (!checked) {
+					ret.append(" style=\"display:none\"");
+				}
+				ret.append(">");
+			}
 			ret.append(" ");
 			if (dateLabel != null) {
 				ret.append(dateLabel);
 			}
 			ret.append(dateWidget.generateHtml(context));
+			if (toggleDateWithCheckbox) {
+				ret.append("</span>");
+				ret.append("<script>setupCheckboxDateToggle('").append(context.getFieldNameIfRegistered(valueWidget))
+				        .append("', '").append(dateHolderId).append("', '")
+				        .append(context.getFieldNameIfRegistered(dateWidget)).append("')</script>");
+			}
 		}
 		if (accessionNumberWidget != null) {
 			ret.append(" ");

--- a/omod/src/main/webapp/resources/htmlFormEntry.js
+++ b/omod/src/main/webapp/resources/htmlFormEntry.js
@@ -675,6 +675,28 @@ function clearDatePickerValue(displaySelector, valueSelector) {
 	jQuery(displaySelector).change();
 }
 
+// For a checkbox-style obs with an associated obs date, the date (label + widget + clear button) should
+// only be shown while the checkbox is checked. When the checkbox is unchecked, the date is hidden and its
+// value cleared so it cannot trigger a "date without value" validation error on a field the user can no
+// longer see.
+function setupCheckboxDateToggle(checkboxFieldName, dateHolderId, dateFieldName) {
+	var checkboxSelector = '#' + checkboxFieldName;
+	var holderSelector = '#' + dateHolderId;
+
+	function syncDateHolderToCheckbox() {
+		if (jQuery(checkboxSelector).is(':checked')) {
+			jQuery(holderSelector).show();
+		} else {
+			jQuery(holderSelector).hide();
+			clearDatePickerValue('#' + dateFieldName + '-display', '#' + dateFieldName);
+		}
+	}
+
+	jQuery(checkboxSelector).change(syncDateHolderToCheckbox);
+
+	syncDateHolderToCheckbox();
+}
+
 // The hour/minute/second fields are only enabled once a date has been entered. If no date is entered,
 // the time fields are disabled (and reset to 00), so the DateTimeWidget is treated as having no value.
 function setupDateTimeValidation(dateFieldName, timeFieldName) {


### PR DESCRIPTION
Before:
<img width="911" height="346" alt="image" src="https://github.com/user-attachments/assets/133f5568-4d63-4ec3-922a-9fe2d70c8b3b" />

After:
<img width="1664" height="231" alt="image" src="https://github.com/user-attachments/assets/aa77db5e-79ac-4f34-b7da-564ba705c982" />

<img width="1664" height="231" alt="image" src="https://github.com/user-attachments/assets/b3eb3b99-bc04-4bae-bfcf-713b2c518c5d" />
